### PR TITLE
refactor: 重构为跨平台OneBot网关架构，移除ZeroBot依赖

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,28 +1,46 @@
-# ── 数据库（含 pgvector 扩展）──
+# ── PostgreSQL（含 pgvector 扩展）──
 LANMEI_DATABASE_URL=postgres://lanmei:lanmei@localhost:5432/lanmei?sslmode=disable
 
 # ── Redis（Conduit 状态存储）──
 LANMEI_REDIS_ADDR=localhost:6379
 
-# ── 向量维度（需与 Embedding 模型匹配）──
-LANMEI_AI_EMBEDDING_DIM=1024
+# ── 网关（反向 WebSocket 服务端，接受 Onebots/NapCat 连接）──
+# 监听地址，Docker 内使用 0.0.0.0:8080，本地开发可用 127.0.0.1:8080
+LANMEI_BOT_GATEWAY_LISTEN_ADDR=0.0.0.0:8080
+# 鉴权 token，Onebots/NapCat 连接时需携带此 token
+# 留空则不鉴权（仅建议本地开发使用）
+LANMEI_BOT_GATEWAY_ACCESS_TOKEN=
 
-# ── LLOneBot 通信 ──
-LANMEI_BOT_WS_URL=ws://127.0.0.1:3001
-LANMEI_BOT_ACCESS_TOKEN=
-# Docker Compose 使用此地址访问宿主机上运行的 LLOneBot。
-LANMEI_DOCKER_BOT_WS_URL=ws://host.docker.internal:3001
-
-# ── 机器人配置 ──
+# ── 机器人 ──
 LANMEI_BOT_NICKNAME=蓝妹
+# 超级用户，格式：platform:userID,逗号分隔
+# 示例：qq:123456,wechat:wxid_xxx,napcat:654321
 LANMEI_BOT_SUPER_USERS=
 
-# ── LLM（选一个填，留空则角色扮演不可用）──
+# ── AI 向量维度（需与 Embedding 模型匹配）──
+LANMEI_AI_EMBEDDING_DIM=1024
+
+# ── Wasm 插件根目录 ──
+LANMEI_PLUGIN_ROOT_DIR=./data/plugins
+
+# ── LLM（待实现，当前角色扮演不可用）──
 # LANMEI_AI_LLM_API_KEY=
 # LANMEI_AI_LLM_BASE_URL=https://api.openai.com/v1
 # LANMEI_AI_LLM_MODEL=gpt-4o
 
-# ── Embedding（选一个填，留空则 RAG 不可用）──
+# ── Embedding（待实现，当前 RAG 不可用）──
 # LANMEI_AI_EMBEDDING_API_KEY=
 # LANMEI_AI_EMBEDDING_BASE_URL=https://api.openai.com/v1
 # LANMEI_AI_EMBEDDING_MODEL=text-embedding-3-small
+
+# ── PostgreSQL 容器 ──
+# POSTGRES_USER=lanmei
+# POSTGRES_PASSWORD=lanmei
+# POSTGRES_DB=lanmei
+# POSTGRES_PORT=5432
+
+# ── Redis 容器 ──
+# REDIS_PORT=6379
+
+# ── 蓝妹服务端口映射（主机端口:容器端口）──
+# LANMEI_PORT=8080

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,17 +2,17 @@
 
 ## 项目概况
 
-蓝妹（lanmei-dream）是一个基于 ZeroBot 框架的 QQ 聊天机器人，通过 LLOneBot 的 WebSocket 协议与 QQ 通信。消息路由使用 Conduit（行为树 + 管线架构）。
+蓝妹（lanmei-dream）是一个跨平台聊天机器人，通过反向 WebSocket 网关接入 OneBot 协议（v12/v11）的 IM 平台。支持通过 Onebots 网关连接微信、钉钉、Telegram 等，也支持 NapCat 直连 NTQQ。消息路由使用 Conduit（行为树 + 管线架构）。
 
 ## 技术栈
 
 - **语言**: Go
-- **Bot 框架**: github.com/wdvxdr1123/ZeroBot
+- **网关**: internal/gateway（基于 lxzan/gws 的反向 WS 服务端，OneBot 12/11 协议适配）
 - **消息引擎**: github.com/zrurf/conduit（行为树 + 管线）
 - **数据库**: PostgreSQL 17 + pgvector（GORM ORM + pgx 驱动，参数化查询防注入）
 - **向量搜索**: pgvector 扩展（HNSW 索引，替代 Milvus）
 - **状态缓存**: Redis 7（Conduit StateStore 持久化 + TTL 自动回收）
-- **通信**: LLOneBot WebSocket（driver.NewWebSocketClient）
+- **通信**: 反向 WebSocket（Onebots/NapCat → 蓝妹网关）
 - **LLM / Embedding**: 待定（接口已定义在 internal/ai/llm/ 和 internal/ai/embedding/，具体实现等用户指定）
 
 ## 目录结构
@@ -25,12 +25,14 @@ internal/
     llm/             → LLMClient 接口 + ChatRequest/ChatResponse/Role/Message
     embedding/       → Embedder 接口
     memory/          → MemoryStore 接口（仅接口，实现移至 infra/）
-  bot/               → ZeroBot 初始化 + Conduit 引擎 + 行为树 + Pass 实现
+  bot/               → Conduit 引擎 + 行为树 + Pass 实现 + EventHandler
   command/           → 斜杠命令系统（注册/解析/分发）
   database/          → GORM 连接池、迁移、CRUD（user/conversation/lod），所有查询参数化
+  gateway/           → 反向 WS 服务端 + OneBot 12/11 协议适配 + 连接管理
   infra/             → 基础设施统一管理（PostgreSQL + Redis + pgvector），生命周期 Setup/Close
   model/             → 数据模型（User/Conversation/Memory/EpisodeSummary/TopicCluster/MemoryVector/ConduitState）
-  signin/            → 签到插件
+  plugin/            → Wasm 插件系统（注册表、ABI、宿主函数、权限控制）
+  bizplugin/         → 内置业务插件（签到）
 docs/                → 架构图（drawio + markdown）
 ```
 
@@ -47,6 +49,8 @@ docs/                → 架构图（drawio + markdown）
 - **基础设施**: 新增基础设施（Redis、pgvector 等）统一放入 internal/infra/，通过 infra.Setup() 初始化
 - **向量存储**: 使用 pgvector（PostgreSQL 扩展），不使用独立向量数据库
 - **状态存储**: Conduit StateStore 使用 Redis（TTL 自动过期 + LRU 淘汰）
+- **平台标识**: 用户以 (platform, platform_user_id) 唯一标识，platform 为 qq/wechat/telegram/napcat 等
+- **权限主体**: user::<platform>::<platformUserID>，如 user::qq::123456
 
 ## 关键设计决策
 
@@ -64,6 +68,9 @@ docs/                → 架构图（drawio + markdown）
 - LLMClient / Embedder 是接口，无具体实现，角色扮演因此暂不可用
 - 基础设施层（infra）统一管理所有外部连接（PG + Redis + pgvector），提供 Setup/Close 生命周期
 - 向量存储从 Milvus 切换到 pgvector，减少 3 个容器（etcd + minio + milvus），统一到 PostgreSQL
+- 网关层（gateway）提供反向 WS 服务端，Onebots/NapCat 作为 WS 客户端主动连接
+- OneBot 12 端点：/onebot/v12，OneBot 11 端点：/onebot/v11（NapCat 兼容），通用端点：/onebot
+- NapCat 连接到 /onebot/v11 或通过 ?platform=napcat 查询参数标识
 
 ## 环境变量
 
@@ -72,15 +79,16 @@ docs/                → 架构图（drawio + markdown）
 | DATABASE_URL | postgres://lanmei:lanmei@localhost:5432/lanmei?sslmode=disable | PostgreSQL 连接串（含 pgvector 扩展） |
 | REDIS_ADDR | localhost:6379 | Redis 地址（Conduit StateStore） |
 | EMBEDDING_DIM | 1024 | 向量维度（需与 Embedding 模型匹配） |
-| WS_URL | ws://127.0.0.1:3001 | LLOneBot WebSocket 地址 |
-| ACCESS_TOKEN | （空） | 鉴权 token |
+| BOT_GATEWAY_LISTEN_ADDR | 0.0.0.0:8080 | 网关监听地址（反向 WS） |
+| BOT_GATEWAY_ACCESS_TOKEN | （空） | 网关鉴权 token |
 | BOT_NICKNAME | 蓝妹 | 机器人昵称 |
-| SUPER_USERS | （空） | 超级管理员 QQ 号，逗号分隔 |
+| BOT_SUPER_USERS | （空） | 超级用户，格式：platform:userID,逗号分隔，如 qq:123456,wechat:wxid_xxx |
 
 > **本文档状态：当前有效** — 架构变更时须同步更新此文件。
 
 ## 变更记录
 
+- 2026-07-28：移除 ZeroBot/QQ 强依赖，实现跨平台 OneBot 12/11 网关层（internal/gateway/），基于 lxzan/gws 反向 WS 服务端；用户模型从 QQID 迁移到 (Platform, PlatformUserID)；SuperUsers 格式改为 platform:userID；docker-compose 新增 onebots/napcat 服务
 - 2026-07-25：新增 IntentPass 意图分析管线，自然语言消息由 LLM 判断路由（command/chat/ignore），LLM 未配置时降级为 chat；行为树优先级3从 pipeline.chat 改为 pipeline.intent
 - 2026-07-25：向量存储从 Milvus 切换到 pgvector（PG 扩展 + HNSW 索引），删除 Milvus/etcd/minio 三容器；新增 model.MemoryVector 和 infra/pgvector.go
 - 2026-07-25：新增 internal/infra/ 包统一管理基础设施（PG + Redis + pgvector），Setup/Close 生命周期；Conduit StateStore 从 MemoryStore 切换到 Redis（RedisStore），TTL 自动过期 + LRU 淘汰

--- a/cmd/lanmei/main.go
+++ b/cmd/lanmei/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DaWesen/lanmei-dream/internal/bot"
 	"github.com/DaWesen/lanmei-dream/internal/command"
 	"github.com/DaWesen/lanmei-dream/internal/config"
+	"github.com/DaWesen/lanmei-dream/internal/gateway"
 	"github.com/DaWesen/lanmei-dream/internal/infra"
 	pluginpkg "github.com/DaWesen/lanmei-dream/internal/plugin"
 )
@@ -39,7 +40,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("插件授权服务初始化失败: %v", err)
 	}
-	if err := authorizer.InitBuiltinPolicies(cfg.Bot.ParseSuperUsers()); err != nil {
+	superUserPrincipals := pluginpkg.ParseSuperUsers(cfg.Bot.ParseSuperUsers())
+	if err := authorizer.InitBuiltinPolicies(superUserPrincipals); err != nil {
 		log.Fatalf("插件内置权限初始化失败: %v", err)
 	}
 
@@ -68,7 +70,17 @@ func main() {
 	// ── 插件系统 ──
 	// 创建插件注册表（引擎在 bot.New 中创建，随后通过 SetEngine 注入）
 	pluginReg := pluginpkg.NewRegistry(nil, inf.StateStore, inf.DB, cmdSys)
-	b := bot.New(&cfg.Bot, cmdSys, chatSvc, inf.DB, inf.StateStore, llmClient, pluginReg)
+
+	// ── 网关（反向 WebSocket 服务端）──
+	gwServer := gateway.NewServer(&gateway.ListenConfig{
+		ListenAddr:  cfg.Bot.Gateway.ListenAddr,
+		AccessToken: cfg.Bot.Gateway.AccessToken,
+	}, nil) // handler 稍后由 Bot 设置
+
+	b := bot.New(&cfg.Bot, cmdSys, chatSvc, inf.DB, inf.StateStore, llmClient, pluginReg, gwServer)
+
+	// 将 Bot 注册为网关事件处理器
+	gwServer.SetHandler(b)
 
 	wasmManager, err := pluginpkg.NewWasmManager(&cfg.Plugin, inf.DB, pluginReg, authorizer, nil)
 	if err != nil {
@@ -100,10 +112,11 @@ func main() {
 		<-sigCh
 		log.Println("正在关闭...")
 		pluginReg.StopPlugins(ctx)
+		gwServer.Shutdown()
 		cancel()
 		os.Exit(0)
 	}()
 
-	log.Printf("蓝妹启动，WebSocket → %s", cfg.Bot.WebSocketURL)
+	log.Printf("蓝妹启动，网关监听 → %s", cfg.Bot.Gateway.ListenAddr)
 	b.Run()
 }

--- a/config/napcat/napcat.json
+++ b/config/napcat/napcat.json
@@ -1,0 +1,18 @@
+{
+  "fileLog": true,
+  "consoleLog": true,
+  "fileLogLevel": "debug",
+  "consoleLogLevel": "info",
+  "packetBackend": "auto",
+  "packetServer": "",
+  "o3HookMode": 1,
+  "autoTimeSync": true,
+  "bypass": {
+    "hook": false,
+    "window": false,
+    "module": false,
+    "process": false,
+    "container": false,
+    "js": false
+  }
+}

--- a/config/napcat/napcat_protocol.json
+++ b/config/napcat/napcat_protocol.json
@@ -1,0 +1,21 @@
+{
+  "enable": true,
+  "network": {
+    "httpServers": [],
+    "websocketServers": [],
+    "websocketClients": [
+      {
+        "name": "lanmei",
+        "enable": true,
+        "url": "ws://lanmei:8080/onebot/v11",
+        "messagePostFormat": "array",
+        "reportSelfMessage": false,
+        "reconnectInterval": 5000,
+        "token": "",
+        "debug": false,
+        "heartInterval": 30000,
+        "verifyCertificate": true
+      }
+    ]
+  }
+}

--- a/config/napcat/onebot11.json
+++ b/config/napcat/onebot11.json
@@ -1,0 +1,32 @@
+{
+  "network": {
+    "httpServers": [],
+    "httpSseServers": [],
+    "httpClients": [],
+    "websocketServers": [],
+    "websocketClients": [
+      {
+        "name": "lanmei",
+        "enable": true,
+        "url": "ws://lanmei:8080/onebot/v11",
+        "messagePostFormat": "array",
+        "reportSelfMessage": false,
+        "reconnectInterval": 5000,
+        "token": "",
+        "debug": false,
+        "heartInterval": 30000
+      }
+    ],
+    "plugins": []
+  },
+  "musicSignUrl": "",
+  "enableLocalFile2Url": false,
+  "parseMultMsg": false,
+  "imageDownloadProxy": "",
+  "timeout": {
+    "baseTimeout": 10000,
+    "uploadSpeedKBps": 256,
+    "downloadSpeedKBps": 256,
+    "maxTimeout": 1800000
+  }
+}

--- a/config/onebots/config.yaml
+++ b/config/onebots/config.yaml
@@ -1,0 +1,30 @@
+port: 6727
+log_level: info
+timeout: 30
+general:
+  onebot.v11:
+    use_http: false
+    use_ws: false
+    use_ws_reverse: true
+    ws_reverse_url: ws://lanmei:8080/onebot/v11
+    access_token: ''
+    enable_heartbeat: true
+    heartbeat_interval: 15000
+    post_message_format: array
+  onebot.v12:
+    use_http: false
+    use_ws: false
+    use_ws_reverse: true
+    ws_reverse_url: ws://lanmei:8080/onebot/v12
+    access_token: ''
+    heartbeat_interval: 15000
+  satori.v1:
+    use_http: false
+    use_ws: false
+    token: ''
+    platform: unknown
+  milky.v1:
+    use_http: false
+    use_ws: false
+username: lanmei_onebots
+password: lanmei_pwd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,14 +39,50 @@ services:
     environment:
       LANMEI_DATABASE_URL: postgres://${POSTGRES_USER:-lanmei}:${POSTGRES_PASSWORD:-lanmei}@postgres:5432/${POSTGRES_DB:-lanmei}?sslmode=disable
       LANMEI_REDIS_ADDR: redis:6379
-      LANMEI_BOT_WS_URL: ${LANMEI_DOCKER_BOT_WS_URL:-ws://host.docker.internal:3001}
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+      LANMEI_BOT_GATEWAY_LISTEN_ADDR: "0.0.0.0:8080"
+      LANMEI_BOT_GATEWAY_ACCESS_TOKEN: ${LANMEI_BOT_GATEWAY_ACCESS_TOKEN:-}
+    ports:
+      - "${LANMEI_PORT:-8080}:8080"
     depends_on:
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
 
+  # ── Onebots 网关（统一 IM 平台适配，通过反向 WS 转发事件到蓝妹）──
+  onebots:
+    image: ghcr.io/lc-cn/onebots:master
+    container_name: onebots
+    restart: unless-stopped
+    volumes:
+      # 运行时数据（数据库、日志、审计，可写）
+      - onebots:/data
+      # 版本控制的配置文件（挂载在目录之上，覆盖 data 中的同名文件）
+      - ./config/onebots/config.yaml:/data/config.yaml
+    depends_on:
+      lanmei:
+        condition: service_started
+
+  # ── NapCat（NTQQ 平台 Provider，OneBot 11 方言，通过反向 WS 连接蓝妹）──
+  napcat:
+    image: mlikiowa/napcat-docker:v4.18.13
+    container_name: napcat
+    restart: unless-stopped
+    environment:
+      NAPCAT_GID: ${NAPCAT_QQ_NUMBER:-}
+      NAPCAT_UID: ${NAPCAT_QQ_NUMBER:-}
+    volumes:
+      # 运行时数据（账号配置、WebUI 配置等，可写）
+      - napcat:/app/napcat/config
+      # 版本控制的配置文件（挂载在目录之上，覆盖 data 中的同名文件）
+      - ./config/napcat/onebot11.json:/app/napcat/config/onebot11.json:ro
+      - ./config/napcat/napcat.json:/app/napcat/config/napcat.json:ro
+      - ./config/napcat/napcat_protocol.json:/app/napcat/config/napcat_protocol.json:ro
+    depends_on:
+      lanmei:
+        condition: service_started
+
 volumes:
   pgdata:
+  onebots:
+  napcat:

--- a/docs/architecture.drawio
+++ b/docs/architecture.drawio
@@ -9,10 +9,10 @@
         <mxCell id="ext" value="外部" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;verticalAlign=top;fontStyle=1" vertex="1" parent="1">
           <mxGeometry x="40" y="40" width="200" height="120" as="geometry"/>
         </mxCell>
-        <mxCell id="qq" value="QQ 客户端" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf" vertex="1" parent="1">
+        <mxCell id="qq" value="IM 平台" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf" vertex="1" parent="1">
           <mxGeometry x="60" y="80" width="160" height="40" as="geometry"/>
         </mxCell>
-        <mxCell id="llonebot" value="LLOneBot" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf" vertex="1" parent="1">
+        <mxCell id="llonebot" value="Onebots / NapCat" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf" vertex="1" parent="1">
           <mxGeometry x="60" y="130" width="160" height="40" as="geometry"/>
         </mxCell>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,13 +5,15 @@
 ```mermaid
 graph TB
     subgraph 外部
-        QQ[QQ 客户端]
-        LLOneBot[LLOneBot]
+        IM[IM 平台<br/>微信/钉钉/TG/...]
+        Onebots[Onebots 网关]
+        NapCat[NapCat<br/>NTQQ Provider]
     end
 
     subgraph 蓝妹服务
         Main[main.go 入口]
         Infra[infra.Setup<br/>PG+Redis+pgvector]
+        Gateway[gateway.Server<br/>反向WS网关]
         Bot[bot.Bot]
         Engine[Conduit Engine]
         BT[行为树]
@@ -38,8 +40,10 @@ graph TB
         RD[(Redis 7)]
     end
 
-    QQ -->|消息| LLOneBot
-    LLOneBot -->|WebSocket| Bot
+    IM -->|消息| Onebots
+    Onebots -->|反向WS OneBot12| Gateway
+    NapCat -->|反向WS OneBot11| Gateway
+    Gateway -->|NormalizedMessage| Bot
     Bot -->|Process| Engine
     Engine -->|决策| BT
     BT -->|/admin| CmdPass
@@ -73,7 +77,7 @@ graph TB
 ```mermaid
 sequenceDiagram
     participant U as 用户
-    participant Q as QQ/LLOneBot
+    participant GW as Gateway网关
     participant B as bot.Bot
     participant E as Conduit Engine
     participant BT as 行为树
@@ -86,8 +90,8 @@ sequenceDiagram
     participant P as PostgreSQL+pgvector
     participant R as Redis
 
-    U->>Q: 发消息
-    Q->>B: WebSocket 推送
+    U->>GW: 发消息
+    GW->>B: NormalizedMessage
     B->>E: Process(InputMessage)
 
     E->>BT: Tick(MessageContext)
@@ -177,7 +181,8 @@ graph LR
 erDiagram
     users {
         bigserial id PK
-        bigint qq_id UK
+        varchar platform UK
+        varchar platform_user_id UK
         varchar nickname
         timestamptz created_at
         timestamptz updated_at

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/casbin/casbin/v3 v3.10.0
 	github.com/casbin/gorm-adapter/v3 v3.41.0
 	github.com/extism/go-sdk v1.7.1
+	github.com/lxzan/gws v1.10.0
 	github.com/pgvector/pgvector-go v0.4.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
-	github.com/wdvxdr1123/ZeroBot v1.8.2
 	github.com/zrurf/conduit v0.1.0
 	gorm.io/datatypes v1.2.7
 	gorm.io/driver/postgres v1.6.0
@@ -19,16 +19,12 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/FloatTech/ttl v0.0.0-20250224045156-012b1463287d // indirect
-	github.com/RomiChan/syncx v0.0.0-20240418144900-b7402ffdebc7 // indirect
-	github.com/RomiChan/websocket v1.4.3-0.20251002072000-d3eb41798438 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
 	github.com/casbin/govaluate v1.10.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dylibso/observe-sdk/go v0.0.0-20240819160327-2d926c5d788a // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
-	github.com/fumiama/orbyte v0.0.0-20251002065953-3bb358367eb5 // indirect
 	github.com/glebarez/go-sqlite v1.22.0 // indirect
 	github.com/glebarez/sqlite v1.11.0 // indirect
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
@@ -44,6 +40,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/microsoft/go-mssqldb v1.9.5 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
@@ -52,22 +49,17 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 // indirect
 	github.com/tetratelabs/wazero v1.9.0 // indirect
-	github.com/tidwall/gjson v1.18.0 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
-	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,12 +24,6 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1/go.mod h1:wP83
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 h1:oygO0locgZJe7PpYPXT5A29ZkwJaPqcva7BVeemZOZs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
-github.com/FloatTech/ttl v0.0.0-20250224045156-012b1463287d h1:mUQ/c3wXKsUGa4Sg9DBy01APXKB68PmobhxOyaJI7lY=
-github.com/FloatTech/ttl v0.0.0-20250224045156-012b1463287d/go.mod h1:fHZFWGquNXuHttu9dUYoKuNbm3dzLETnIOnm1muSfDs=
-github.com/RomiChan/syncx v0.0.0-20240418144900-b7402ffdebc7 h1:S/ferNiehVjNaBMNNBxUjLtVmP/YWD6Yh79RfPv4ehU=
-github.com/RomiChan/syncx v0.0.0-20240418144900-b7402ffdebc7/go.mod h1:vD7Ra3Q9onRtojoY5sMCLQ7JBgjUsrXDnDKyFxqpf9w=
-github.com/RomiChan/websocket v1.4.3-0.20251002072000-d3eb41798438 h1:I0bdwHZ+2DY45b39xPoTD2u+Z8zhvBuu9aZfjMZeiZM=
-github.com/RomiChan/websocket v1.4.3-0.20251002072000-d3eb41798438/go.mod h1:GO+9i5UYB4BuZEel6BfGx7O1u3ggwgZWUnGxPATUoTE=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
@@ -62,8 +56,6 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/fumiama/orbyte v0.0.0-20251002065953-3bb358367eb5 h1:j9o0XVvdAeLwrBYMnh0SerrMc9CgNU6AGszbsvFzoc0=
-github.com/fumiama/orbyte v0.0.0-20251002065953-3bb358367eb5/go.mod h1:FOjdw7KdCbK2eH3gRPhwFNCoXKpu9sN5vPH4El/8e0c=
 github.com/glebarez/go-sqlite v1.22.0 h1:uAcMJhaA6r3LHMTFgP0SifzgXg46yJkgxqyuyec+ruQ=
 github.com/glebarez/go-sqlite v1.22.0/go.mod h1:PlBIdHe0+aUEFn+r2/uthrWq4FxbzugL0L8Li6yQJbc=
 github.com/glebarez/sqlite v1.11.0 h1:wSG0irqzP6VurnMEpFGer5Li19RpIRi2qvQz++w0GMw=
@@ -115,6 +107,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
+github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -128,6 +122,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lxzan/gws v1.10.0 h1:mNU2nqD7QEGzg9QWxUw8wNy4ByBFv2QKmKRgoLdejSA=
+github.com/lxzan/gws v1.10.0/go.mod h1:gXHSCPmTGryWJ4icuqy8Yho32E4YIMHH0fkDRYJRbdc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
@@ -162,8 +158,6 @@ github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDc
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
@@ -194,14 +188,6 @@ github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 h1:ZF+QBjOI+tILZ
 github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834/go.mod h1:m9ymHTgNSEjuxvw8E7WWe4Pl4hZQHXONY8wE6dMLaRk=
 github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
 github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
-github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
-github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
-github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
-github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/wdvxdr1123/ZeroBot v1.8.2 h1:H4qNHgeYLLm3ID5T9MKnO4fI0SWWl0rFCGLCUr8u10M=
-github.com/wdvxdr1123/ZeroBot v1.8.2/go.mod h1:trueIIVRywKJa3ov4QphzVvzYzgCNrlXdf9JvPJOFW8=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
@@ -270,7 +256,6 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/bizplugin/signin.go
+++ b/internal/bizplugin/signin.go
@@ -151,7 +151,11 @@ func (pass *signinExecutePass) Execute(ctx *conduit.MessageContext) error {
 
 	// 确保用户存在
 	if pass.db != nil {
-		_, _ = pass.db.GetOrCreateUser(ctx.Ctx, parseUserID64(ctx.UserID), "")
+		platform, _ := conduit.Get[string](ctx, "platform")
+		if platform == "" {
+			platform = "unknown"
+		}
+		_, _ = pass.db.GetOrCreateUser(ctx.Ctx, platform, ctx.UserID, "")
 	}
 
 	// 从 StateStore 读取签到记录
@@ -236,6 +240,7 @@ func (pass *signinReplyPass) Execute(ctx *conduit.MessageContext) error {
 // ============================================================
 
 // parseUserID64 将字符串用户 ID 解析为 int64
+// 已废弃，仅用于向后兼容
 func parseUserID64(s string) int64 {
 	var id int64
 	fmt.Sscanf(s, "%d", &id)

--- a/internal/bot/README.md
+++ b/internal/bot/README.md
@@ -1,8 +1,8 @@
-# bot 包 —— ZeroBot 消息处理层
+# bot 包 —— 消息处理层
 
 ## 职责
 
-负责 ZeroBot 的初始化和消息分发，使用 Conduit 引擎（行为树 + 管线）路由消息。
+负责接收网关标准化消息并分发，使用 Conduit 引擎（行为树 + 管线）路由消息，通过网关回复。
 
 ## 核心设计
 
@@ -11,7 +11,7 @@
 所有用户消息通过 Conduit 引擎处理，行为树按优先级路由：
 
 ```
-ZeroBot 收到消息 → engine.Process(InputMessage)
+Gateway 收到 NormalizedMessage → engine.Process(InputMessage)
         │
         ▼
    行为树决策
@@ -44,6 +44,7 @@ ZeroBot 收到消息 → engine.Process(InputMessage)
 ### 关键依赖
 
 - `github.com/zrurf/conduit` — 引擎、行为树、管线
+- `internal/gateway` — 网关（反向 WS 服务端 + OneBot 协议适配）
 - `internal/ai` — ChatService、IntentAnalyzer
 - `internal/command` — 命令系统
 - `internal/database` — 数据库访问

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -2,11 +2,8 @@ package bot
 
 import (
 	"log"
-	"strconv"
 	"time"
 
-	zero "github.com/wdvxdr1123/ZeroBot"
-	"github.com/wdvxdr1123/ZeroBot/driver"
 	"github.com/zrurf/conduit"
 
 	"github.com/DaWesen/lanmei-dream/internal/ai"
@@ -14,14 +11,15 @@ import (
 	"github.com/DaWesen/lanmei-dream/internal/command"
 	"github.com/DaWesen/lanmei-dream/internal/config"
 	"github.com/DaWesen/lanmei-dream/internal/database"
+	"github.com/DaWesen/lanmei-dream/internal/gateway"
 	pluginpkg "github.com/DaWesen/lanmei-dream/internal/plugin"
 )
 
-// Bot 封装 ZeroBot + Conduit 引擎
+// Bot 封装 Conduit 引擎 + 网关服务
 type Bot struct {
-	cfg     *zero.Config
 	engine  *conduit.Engine
 	plugins *pluginpkg.Registry
+	gw      *gateway.Server
 }
 
 // New 创建 Bot 实例，初始化 Conduit 引擎、行为树和插件系统。
@@ -29,13 +27,12 @@ type Bot struct {
 // store 为 Conduit 状态存储（由 infra 包提供，RedisStore 用于生产，MemoryStore 用于测试）
 // llmClient 为 LLM 客户端，用于意图分析（nil 时降级为纯聊天路由）
 // pluginReg 为插件注册表（nil 时跳过插件初始化）
-func New(cfg *config.BotConfig, cmdSys *command.System, chatSvc *ai.ChatService, db *database.DB, store conduit.StateStore, llmClient llm.LLMClient, pluginReg *pluginpkg.Registry) *Bot {
+// gwServer 为网关服务端（反向 WS，由 gateway 包提供）
+func New(cfg *config.BotConfig, cmdSys *command.System, chatSvc *ai.ChatService, db *database.DB, store conduit.StateStore, llmClient llm.LLMClient, pluginReg *pluginpkg.Registry, gwServer *gateway.Server) *Bot {
 	nick := cfg.NickName
 	if nick == "" {
 		nick = "蓝妹"
 	}
-
-	superUsers := cfg.ParseSuperUsers()
 
 	// ── Conduit 引擎 ──
 	engine := conduit.New(store,
@@ -88,20 +85,10 @@ func New(cfg *config.BotConfig, cmdSys *command.System, chatSvc *ai.ChatService,
 	bt := buildBehaviorTree(pluginReg, coreAdmin, coreCommand, coreIntent)
 	engine.SetBehaviorTree(bt)
 
-	// ── ZeroBot 配置 ──
-	zeroCfg := &zero.Config{
-		NickName:      []string{nick},
-		CommandPrefix: "/",
-		SuperUsers:    superUsers,
-		Driver: []zero.Driver{
-			driver.NewWebSocketClient(cfg.WebSocketURL, cfg.AccessToken),
-		},
-	}
-
 	return &Bot{
-		cfg:     zeroCfg,
 		engine:  engine,
 		plugins: pluginReg,
+		gw:      gwServer,
 	}
 }
 
@@ -133,41 +120,34 @@ func buildBehaviorTree(pluginReg *pluginpkg.Registry, coreAdmin, coreCommand, co
 	return conduit.NewBehaviorTree(branches...)
 }
 
-// Run 启动 Conduit 引擎 + 插件 + ZeroBot，阻塞运行
+// Run 启动 Conduit 引擎 + 网关服务，阻塞运行
 func (b *Bot) Run() {
 	b.engine.Start()
 	defer func() { _ = b.engine.Stop() }()
 
-	zero.OnMessage().Handle(b.handleMessage)
-
-	zero.RunAndBlock(b.cfg, nil)
+	if err := b.gw.Run(); err != nil {
+		log.Fatalf("gateway: 服务运行失败: %v", err)
+	}
 }
 
-// handleMessage 把 ZeroBot 消息转为 Conduit InputMessage，同步处理后回复
-func (b *Bot) handleMessage(ctx *zero.Ctx) {
-	msg := ctx.ExtractPlainText()
-	if msg == "" {
-		msg = ctx.Event.RawMessage
-	}
-	if msg == "" {
+// OnMessage 实现 gateway.EventHandler 接口，将网关消息转为 Conduit 输入
+func (b *Bot) OnMessage(msg *gateway.NormalizedMessage) {
+	if msg.Content == "" {
 		return
 	}
 
-	qqID := strconv.FormatInt(ctx.Event.UserID, 10)
-	groupID := ""
-	isGroup := ctx.Event.GroupID != 0
-	if isGroup {
-		groupID = strconv.FormatInt(ctx.Event.GroupID, 10)
-	}
-
 	input := &conduit.InputMessage{
-		UserID:  qqID,
-		GroupID: groupID,
-		Content: msg,
-		IsGroup: isGroup,
+		UserID:  msg.UserID,
+		GroupID: msg.GroupID,
+		Content: msg.Content,
+		IsGroup: msg.IsGroup,
 		Extra: map[string]any{
-			KeyQQUserID: ctx.Event.UserID,
-			KeyNickname: ctx.Event.Sender.NickName,
+			KeyPlatform:       string(msg.Platform),
+			KeyPlatformUserID: msg.UserID,
+			KeyNickname:       msg.SenderName,
+			KeyMessageID:      msg.MessageID,
+			KeyConnID:         msg.ConnID,
+			KeySelfID:         msg.SelfID,
 		},
 	}
 
@@ -175,12 +155,19 @@ func (b *Bot) handleMessage(ctx *zero.Ctx) {
 	result, err := b.engine.Process(input)
 	if err != nil {
 		log.Printf("conduit: process failed: %v", err)
-		ctx.Send("蓝妹现在有点迷糊，稍后再试~")
+		b.reply(msg, "蓝妹现在有点迷糊，稍后再试~")
 		return
 	}
 
 	// 发送所有输出消息
 	for _, out := range result.Output {
-		ctx.Send(out.Content)
+		b.reply(msg, out.Content)
+	}
+}
+
+// reply 通过网关回复消息
+func (b *Bot) reply(msg *gateway.NormalizedMessage, text string) {
+	if err := b.gw.Hub().SendMessageTo(msg.ConnID, msg, text); err != nil {
+		log.Printf("bot: 回复失败 conn=%s err=%v", msg.ConnID, err)
 	}
 }

--- a/internal/bot/passes.go
+++ b/internal/bot/passes.go
@@ -2,7 +2,6 @@ package bot
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/zrurf/conduit"
@@ -17,8 +16,12 @@ import (
 // ── 上下文键 ──
 
 const (
-	KeyQQUserID = "qq_user_id" // int64 QQ 用户 ID（存在 Extra 中）
-	KeyNickname = "nickname"   // string 昵称（存在 Extra 中）
+	KeyPlatform       = "platform"        // string 平台标识（qq/wechat/telegram/...）
+	KeyPlatformUserID = "platform_user_id" // string 平台用户 ID
+	KeyNickname       = "nickname"         // string 昵称
+	KeyMessageID      = "message_id"       // string 消息 ID
+	KeyConnID         = "conn_id"          // string 来源连接 ID
+	KeySelfID         = "self_id"          // string 机器人自身 ID
 )
 
 // ── CommandPass：处理斜杠命令 ──
@@ -32,11 +35,12 @@ func (p *CommandPass) Execute(ctx *conduit.MessageContext) error {
 	// 收集命令回复
 	var replies []string
 	err := p.CmdSys.Process(ctx.RawMsg, &command.Context{
-		UserID:  qqUserID(ctx),
-		GroupID: ctx.GroupID,
-		IsGroup: ctx.IsGroup,
-		Message: ctx.RawMsg,
-		Reply:   func(s string) { replies = append(replies, s) },
+		Platform:       platformFromCtx(ctx),
+		PlatformUserID: platformUserIDFromCtx(ctx),
+		GroupID:        ctx.GroupID,
+		IsGroup:        ctx.IsGroup,
+		Message:        ctx.RawMsg,
+		Reply:          func(s string) { replies = append(replies, s) },
 	})
 
 	// 将回复追加到输出
@@ -66,11 +70,12 @@ func (p *RoleplayPass) Execute(ctx *conduit.MessageContext) error {
 		return nil
 	}
 
-	qqID := qqUserID(ctx)
+	platform := platformFromCtx(ctx)
+	platformUserID := platformUserIDFromCtx(ctx)
 	nickname, _ := conduit.Get[string](ctx, KeyNickname)
 
 	// 确保用户存在
-	user, err := p.DB.GetOrCreateUser(ctx.Ctx, qqID, nickname)
+	user, err := p.DB.GetOrCreateUser(ctx.Ctx, platform, platformUserID, nickname)
 	if err != nil {
 		return fmt.Errorf("roleplay: get_or_create_user: %w", err)
 	}
@@ -141,17 +146,20 @@ func IsAdminCommand(ctx *conduit.MessageContext) bool {
 
 // ── 辅助函数 ──
 
-func qqUserID(ctx *conduit.MessageContext) int64 {
-	// 优先从 Extra 取 int64 类型的 QQ ID
-	if raw, ok := ctx.Extra[KeyQQUserID]; ok {
-		if id, ok := raw.(int64); ok {
-			return id
+func platformFromCtx(ctx *conduit.MessageContext) string {
+	if raw, ok := ctx.Extra[KeyPlatform]; ok {
+		if s, ok := raw.(string); ok {
+			return s
 		}
 	}
-	// fallback：从 UserID 字符串解析
-	id, err := strconv.ParseInt(ctx.UserID, 10, 64)
-	if err != nil {
-		return 0
+	return "unknown"
+}
+
+func platformUserIDFromCtx(ctx *conduit.MessageContext) string {
+	if raw, ok := ctx.Extra[KeyPlatformUserID]; ok {
+		if s, ok := raw.(string); ok {
+			return s
+		}
 	}
-	return id
+	return ctx.UserID
 }

--- a/internal/command/module.go
+++ b/internal/command/module.go
@@ -9,11 +9,12 @@ import (
 
 // Context 是命令处理函数的上下文。
 type Context struct {
-	UserID  int64
-	GroupID string
-	IsGroup bool
-	Message string
-	Reply   func(string)
+	Platform       string // 平台标识（qq/wechat/telegram/...）
+	PlatformUserID string // 平台用户 ID
+	GroupID        string
+	IsGroup        bool
+	Message        string
+	Reply          func(string)
 }
 
 // Command 定义一个斜杠命令。

--- a/internal/command/module_test.go
+++ b/internal/command/module_test.go
@@ -47,14 +47,12 @@ func TestSystemConcurrentProcess(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 64 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			ctx := &Context{UserID: 1, Reply: func(string) {}}
+		wg.Go(func() {
+			ctx := &Context{Platform: "qq", PlatformUserID: "1", Reply: func(string) {}}
 			if err := s.Process("/ping", ctx); err != nil {
 				t.Errorf("process error: %v", err)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"strconv"
 	"strings"
 )
 
@@ -36,28 +35,18 @@ type AIConfig struct {
 
 // BotConfig 机器人配置
 type BotConfig struct {
-	WebSocketURL string `mapstructure:"ws_url"`
-	AccessToken  string `mapstructure:"access_token"`
-	NickName     string `mapstructure:"nickname"`
-	SuperUsers   string `mapstructure:"super_users"`
+	NickName   string      `mapstructure:"nickname"`
+	SuperUsers string      `mapstructure:"super_users"` // 格式：platform:userID,... 如 qq:123456,wechat:wxid_xxx
+	Gateway    GatewayConfig `mapstructure:"gateway"`
 }
 
-// ParseSuperUsers 将 SuperUsers 逗号分隔字符串转换为 int64 列表
-// 例如 "123,456" → []int64{123, 456}
-func (c *BotConfig) ParseSuperUsers() []int64 {
-	if c.SuperUsers == "" {
-		return nil
-	}
-	parts := strings.Split(c.SuperUsers, ",")
-	users := make([]int64, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		if id, err := strconv.ParseInt(p, 10, 64); err == nil {
-			users = append(users, id)
-		}
-	}
-	return users
+// GatewayConfig 网关（反向 WebSocket 服务端）配置
+type GatewayConfig struct {
+	ListenAddr  string `mapstructure:"listen_addr"`  // 监听地址，如 "0.0.0.0:8080"
+	AccessToken string `mapstructure:"access_token"` // 鉴权 token（空则不鉴权）
+}
+
+// ParseSuperUsers 返回原始超级用户字符串，供 plugin.ParseSuperUsers 使用
+func (c *BotConfig) ParseSuperUsers() string {
+	return strings.TrimSpace(c.SuperUsers)
 }

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -32,7 +32,7 @@ func Init() (*Config, error) {
 		}
 	}
 
-	// 环境变量：LANMEI_DATABASE_URL、LANMEI_BOT_WS_URL 等
+	// 环境变量：LANMEI_DATABASE_URL、LANMEI_BOT_GATEWAY_LISTEN_ADDR 等
 	v.SetEnvPrefix("LANMEI")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
@@ -58,10 +58,10 @@ func initFlags() {
 	pflag.String("database.url", "", "PostgreSQL 连接字符串")
 	pflag.String("redis.addr", "", "Redis 地址")
 	pflag.Int("ai.embedding_dim", 0, "向量维度")
-	pflag.String("bot.ws_url", "", "WebSocket 地址")
-	pflag.String("bot.access_token", "", "Access Token")
+	pflag.String("bot.gateway.listen_addr", "", "网关监听地址")
+	pflag.String("bot.gateway.access_token", "", "网关鉴权 token")
 	pflag.String("bot.nickname", "", "机器人昵称")
-	pflag.String("bot.super_users", "", "超级用户ID列表（逗号分隔）")
+	pflag.String("bot.super_users", "", "超级用户列表（格式：platform:userID,逗号分隔）")
 	pflag.String("plugin.root_dir", "", "Wasm 插件根目录")
 }
 
@@ -76,11 +76,11 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("ai.embedding_dim", 1024)
 
 	// Bot 默认值
-	v.SetDefault("bot.ws_url", "ws://127.0.0.1:3001")
-	v.SetDefault("bot.access_token", "")
+	v.SetDefault("bot.gateway.listen_addr", "0.0.0.0:8080")
+	v.SetDefault("bot.gateway.access_token", "")
 	v.SetDefault("bot.nickname", "蓝妹")
+	v.SetDefault("bot.super_users", "")
 
 	// Plugin 默认值
 	v.SetDefault("plugin.root_dir", "./data/plugins")
-	v.SetDefault("bot.super_users", "")
 }

--- a/internal/database/user.go
+++ b/internal/database/user.go
@@ -8,14 +8,14 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// GetOrCreateUser 按 QQ 号查找或创建用户（使用 GORM clause.OnConflict 实现幂等 upsert）
-func (db *DB) GetOrCreateUser(ctx context.Context, qqID int64, nickname string) (*model.User, error) {
+// GetOrCreateUser 按 (platform, platform_user_id) 查找或创建用户（使用 GORM clause.OnConflict 实现幂等 upsert）
+func (db *DB) GetOrCreateUser(ctx context.Context, platform, platformUserID, nickname string) (*model.User, error) {
 	var u model.User
 	result := db.Orm.WithContext(ctx).
-		Where(model.User{QQID: qqID}).
+		Where(model.User{Platform: platform, PlatformUserID: platformUserID}).
 		Attrs(model.User{Nickname: nickname}).
 		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "qq_id"}},
+			Columns:   []clause.Column{{Name: "platform"}, {Name: "platform_user_id"}},
 			DoUpdates: clause.AssignmentColumns([]string{"nickname", "updated_at"}),
 		}).
 		FirstOrCreate(&u)

--- a/internal/gateway/event.go
+++ b/internal/gateway/event.go
@@ -1,0 +1,91 @@
+package gateway
+
+import "encoding/json"
+
+// ── 平台与协议标识 ──
+
+// Platform 标识消息来源的 IM 平台
+type Platform string
+
+const (
+	PlatformQQ       Platform = "qq"       // 通过 Onebots 网关连接的 QQ
+	PlatformWechat   Platform = "wechat"   // 微信
+	PlatformTelegram Platform = "telegram" // Telegram
+	PlatformDing     Platform = "ding"     // 钉钉
+	PlatformNapCat   Platform = "napcat"   // NapCat 直连（NTQQ）
+)
+
+// Protocol 标识 OneBot 协议版本
+type Protocol string
+
+const (
+	ProtocolV12 Protocol = "onebot12" // 标准 OneBot 12
+	ProtocolV11 Protocol = "onebot11" // OneBot 11（NapCat 方言）
+)
+
+// ── OneBot 12 事件 ──
+
+// EventV12 表示 OneBot 12 标准事件
+type EventV12 struct {
+	ID         string              `json:"id"`
+	Impl       string              `json:"impl"`
+	Platform   string              `json:"platform"`
+	SelfID     string              `json:"self_id"`
+	Time       float64             `json:"time"`
+	Type       string              `json:"type"`        // meta / message / notice / request
+	DetailType string              `json:"detail_type"` // private / group / ...
+	SubType    string              `json:"sub_type"`
+	UserID     string              `json:"user_id,omitempty"`
+	GroupID    string              `json:"group_id,omitempty"`
+	Message    []MessageSegmentV12 `json:"message,omitempty"`
+	AltMessage string              `json:"alt_message,omitempty"` // 纯文本表示
+}
+
+// ── OneBot 11 事件（NapCat 兼容） ──
+
+// EventV11 表示 OneBot 11 风格事件（NapCat 方言）
+//
+// 注意：Message 字段使用 json.RawMessage 而非具体类型，
+// 以避免 API 响应的 "message":""（string）与事件 "message":[{...}]（array）冲突。
+type EventV11 struct {
+	Time        int64           `json:"time"`
+	SelfID      int64           `json:"self_id"`
+	PostType    string          `json:"post_type"`              // message / notice / request / meta_event
+	MessageType string          `json:"message_type,omitempty"` // private / group
+	SubType     string          `json:"sub_type,omitempty"`
+	UserID      int64           `json:"user_id,omitempty"`
+	GroupID     int64           `json:"group_id,omitempty"`
+	Message     json.RawMessage `json:"message,omitempty"` // array of MessageSegmentV11 or string
+	RawMessage  string          `json:"raw_message,omitempty"`
+	Sender      SenderV11       `json:"sender,omitempty"`
+	// 消息 ID（NapCat 扩展）
+	MessageID  int64 `json:"message_id,omitempty"`
+	MessageSeq int64 `json:"message_seq,omitempty"`
+}
+
+// ParseMessageSegments 将 Message 字段解析为 OneBot 11 消息段列表。
+//
+// 兼容两种格式：
+//   - array:  [{"type":"text","data":{"text":"hi"}}]
+//   - string: ""（API 响应中的空字符串）或 CQ 码（暂不支持）
+func (e *EventV11) ParseMessageSegments() []MessageSegmentV11 {
+	if len(e.Message) == 0 {
+		return nil
+	}
+	var segments []MessageSegmentV11
+	if err := json.Unmarshal(e.Message, &segments); err == nil {
+		return segments
+	}
+	// 非数组格式（string/null/其他），返回空
+	return nil
+}
+
+// SenderV11 表示 OneBot 11 消息发送者
+type SenderV11 struct {
+	UserID   int64  `json:"user_id"`
+	Nickname string `json:"nickname"`
+	Sex      string `json:"sex,omitempty"`
+	Age      int    `json:"age,omitempty"`
+	Card     string `json:"card,omitempty"` // 群名片
+	Role     string `json:"role,omitempty"` // owner / admin / member
+}

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -1,0 +1,122 @@
+package gateway
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/lxzan/gws"
+)
+
+// Connection 表示一个反向 WebSocket 连接（来自 Onebots 或 NapCat）
+type Connection struct {
+	ID       string    // 连接唯一标识
+	Platform Platform  // 来源平台
+	Protocol Protocol  // OneBot 协议版本
+	SelfID   string    // 机器人自身 ID（并发写入，通过 mu 保护）
+	Impl     string    // OneBot 实现名（并发写入，通过 mu 保护）
+	Socket   *gws.Conn // 底层 gws 连接
+
+	mu sync.Mutex // 保护 SelfID、Impl 的并发写入
+}
+
+// SetSelfID 安全设置 SelfID（仅首次设置生效）
+func (c *Connection) SetSelfID(id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.SelfID == "" {
+		c.SelfID = id
+	}
+}
+
+// SetImpl 安全设置 Impl（仅首次设置生效）
+func (c *Connection) SetImpl(impl string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.Impl == "" {
+		c.Impl = impl
+	}
+}
+
+// Hub 管理所有活跃的反向 WS 连接
+type Hub struct {
+	mu    sync.RWMutex
+	conns map[string]*Connection // 连接ID → Connection
+}
+
+// NewHub 创建连接管理中心
+func NewHub() *Hub {
+	return &Hub{conns: make(map[string]*Connection)}
+}
+
+// Register 注册新连接
+func (h *Hub) Register(conn *Connection) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.conns[conn.ID] = conn
+}
+
+// Unregister 移除连接
+func (h *Hub) Unregister(connID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.conns, connID)
+}
+
+// Get 获取指定连接
+func (h *Hub) Get(connID string) (*Connection, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	c, ok := h.conns[connID]
+	return c, ok
+}
+
+// SendTo 向指定连接发送动作请求
+func (h *Hub) SendTo(connID string, req *ActionRequest) error {
+	h.mu.RLock()
+	conn, ok := h.conns[connID]
+	h.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("gateway: 连接 %s 不存在", connID)
+	}
+	return writeJSON(conn.Socket, req)
+}
+
+// SendMessageTo 向指定连接发送文本消息（自动选择协议动作）
+func (h *Hub) SendMessageTo(connID string, msg *NormalizedMessage, text string) error {
+	h.mu.RLock()
+	conn, ok := h.conns[connID]
+	h.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("gateway: 连接 %s 不存在", connID)
+	}
+
+	var req *ActionRequest
+	if conn.Protocol == ProtocolV11 {
+		req = BuildSendMessageV11(msg.IsGroup, msg.UserID, msg.GroupID, text)
+	} else {
+		detailType := "private"
+		if msg.IsGroup {
+			detailType = "group"
+		}
+		req = BuildSendMessageV12(detailType, msg.UserID, msg.GroupID, text)
+	}
+	return writeJSON(conn.Socket, req)
+}
+
+// All 返回所有活跃连接的快照
+func (h *Hub) All() []*Connection {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	result := make([]*Connection, 0, len(h.conns))
+	for _, c := range h.conns {
+		result = append(result, c)
+	}
+	return result
+}
+
+// Count 返回活跃连接数
+func (h *Hub) Count() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.conns)
+}

--- a/internal/gateway/message.go
+++ b/internal/gateway/message.go
@@ -1,0 +1,250 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ── OneBot 12 消息段 ──
+
+// MessageSegmentV12 表示 OneBot 12 消息段
+type MessageSegmentV12 struct {
+	Type string         `json:"type"` // text / image / at / reply / ...
+	Data map[string]any `json:"data"`
+}
+
+// TextContent 提取消息段的纯文本内容
+func (m MessageSegmentV12) TextContent() string {
+	switch m.Type {
+	case "text":
+		if s, ok := m.Data["text"].(string); ok {
+			return s
+		}
+	case "at":
+		if uid, ok := m.Data["user_id"].(string); ok {
+			return "@" + uid
+		}
+	}
+	return ""
+}
+
+// ExtractPlainText 从 OneBot 12 消息段列表提取纯文本
+func ExtractPlainTextV12(segments []MessageSegmentV12) string {
+	var parts []string
+	for _, seg := range segments {
+		if t := seg.TextContent(); t != "" {
+			parts = append(parts, t)
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// ── OneBot 11 消息段 ──
+
+// MessageSegmentV11 表示 OneBot 11 消息段（NapCat 方言）
+type MessageSegmentV11 struct {
+	Type string         `json:"type"` // text / image / at / face / reply / ...
+	Data map[string]any `json:"data"`
+}
+
+// TextContent 提取消息段的纯文本内容
+func (m MessageSegmentV11) TextContent() string {
+	switch m.Type {
+	case "text":
+		if s, ok := m.Data["text"].(string); ok {
+			return s
+		}
+	case "at":
+		// NapCat 的 at 消息段，qq 字段可能是 number 或 string
+		if qq := m.Data["qq"]; qq != nil {
+			return "@" + formatIntOrString(qq)
+		}
+	}
+	return ""
+}
+
+// ExtractPlainTextV11 从 OneBot 11 消息段列表提取纯文本
+func ExtractPlainTextV11(segments []MessageSegmentV11) string {
+	var parts []string
+	for _, seg := range segments {
+		if t := seg.TextContent(); t != "" {
+			parts = append(parts, t)
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// ── 标准化消息 ──
+
+// NormalizedMessage 是跨平台标准化后的消息，供 bot 层消费
+type NormalizedMessage struct {
+	Platform   Platform // 来源平台
+	Protocol   Protocol // 协议版本
+	SelfID     string   // 机器人自身 ID
+	UserID     string   // 平台用户 ID（字符串，跨平台）
+	GroupID    string   // 平台群 ID（空字符串 = 私聊）
+	IsGroup    bool     // 是否群消息
+	Content    string   // 纯文本内容
+	SenderName string   // 发送者昵称
+	MessageID  string   // 消息 ID
+	ConnID     string   // 来源连接 ID（用于回复路由）
+}
+
+// NormalizeV12 将 OneBot 12 事件标准化为 NormalizedMessage
+func NormalizeV12(connID string, evt *EventV12, platform Platform) *NormalizedMessage {
+	if evt.Type != "message" {
+		return nil
+	}
+
+	userID := evt.UserID
+	groupID := evt.GroupID
+	isGroup := evt.DetailType == "group"
+
+	content := evt.AltMessage
+	if content == "" {
+		content = ExtractPlainTextV12(evt.Message)
+	}
+
+	// 如果事件平台字段有效，优先使用事件中的平台标识
+	p := platform
+	if evt.Platform != "" {
+		p = Platform(evt.Platform)
+	}
+
+	return &NormalizedMessage{
+		Platform:   p,
+		Protocol:   ProtocolV12,
+		SelfID:     evt.SelfID,
+		UserID:     userID,
+		GroupID:    groupID,
+		IsGroup:    isGroup,
+		Content:    content,
+		SenderName: "", // OB12 消息事件不直接包含 sender nickname，需从 sender 子对象获取（如有）
+		MessageID:  evt.ID,
+		ConnID:     connID,
+	}
+}
+
+// NormalizeV11 将 OneBot 11 事件标准化为 NormalizedMessage
+func NormalizeV11(connID string, evt *EventV11, platform Platform) *NormalizedMessage {
+	if evt.PostType != "message" {
+		return nil
+	}
+
+	userID := strconv.FormatInt(evt.UserID, 10)
+	groupID := ""
+	isGroup := evt.MessageType == "group"
+	if isGroup {
+		groupID = strconv.FormatInt(evt.GroupID, 10)
+	}
+
+	content := evt.RawMessage
+	if content == "" {
+		content = ExtractPlainTextV11(evt.ParseMessageSegments())
+	}
+
+	senderName := evt.Sender.Nickname
+	if isGroup && evt.Sender.Card != "" {
+		senderName = evt.Sender.Card
+	}
+
+	messageID := strconv.FormatInt(evt.MessageID, 10)
+
+	return &NormalizedMessage{
+		Platform:   platform,
+		Protocol:   ProtocolV11,
+		SelfID:     strconv.FormatInt(evt.SelfID, 10),
+		UserID:     userID,
+		GroupID:    groupID,
+		IsGroup:    isGroup,
+		Content:    content,
+		SenderName: senderName,
+		MessageID:  messageID,
+		ConnID:     connID,
+	}
+}
+
+// ── 动作请求/响应 ──
+
+// ActionRequest 表示要发送给 OneBot 实现的动作请求
+type ActionRequest struct {
+	Action string         `json:"action"`         // 动作名，如 send_message / send_group_msg
+	Params map[string]any `json:"params"`         // 动作参数
+	Echo   string         `json:"echo,omitempty"` // 请求标识（用于匹配响应）
+}
+
+// ActionResponse 表示 OneBot 实现返回的动作响应
+type ActionResponse struct {
+	Status  string          `json:"status"`            // ok / failed
+	RetCode int64           `json:"retcode"`           // 返回码
+	Data    json.RawMessage `json:"data"`              // 响应数据
+	Message string          `json:"message,omitempty"` // 错误信息
+	Echo    string          `json:"echo,omitempty"`    // 请求标识
+}
+
+// ── 构建动作辅助 ──
+
+// BuildSendMessageV12 构建 OneBot 12 send_message 动作
+func BuildSendMessageV12(detailType, userID, groupID, text string) *ActionRequest {
+	params := map[string]any{
+		"detail_type": detailType, // private / group
+		"message": []MessageSegmentV12{
+			{Type: "text", Data: map[string]any{"text": text}},
+		},
+	}
+	if detailType == "private" {
+		params["user_id"] = userID
+	} else {
+		params["group_id"] = groupID
+	}
+	return &ActionRequest{
+		Action: "send_message",
+		Params: params,
+	}
+}
+
+// BuildSendMessageV11 构建 OneBot 11 send_private_msg / send_group_msg 动作
+func BuildSendMessageV11(isGroup bool, userID, groupID, text string) *ActionRequest {
+	if isGroup {
+		gid, _ := strconv.ParseInt(groupID, 10, 64)
+		return &ActionRequest{
+			Action: "send_group_msg",
+			Params: map[string]any{
+				"group_id": gid,
+				"message": []MessageSegmentV11{
+					{Type: "text", Data: map[string]any{"text": text}},
+				},
+			},
+		}
+	}
+	uid, _ := strconv.ParseInt(userID, 10, 64)
+	return &ActionRequest{
+		Action: "send_private_msg",
+		Params: map[string]any{
+			"user_id": uid,
+			"message": []MessageSegmentV11{
+				{Type: "text", Data: map[string]any{"text": text}},
+			},
+		},
+	}
+}
+
+// ── 辅助函数 ──
+
+// formatIntOrString 将值格式化为字符串（处理 JSON number 或 string）
+func formatIntOrString(v any) string {
+	switch n := v.(type) {
+	case json.Number:
+		return n.String()
+	case float64:
+		return strconv.FormatInt(int64(n), 10)
+	case int64:
+		return strconv.FormatInt(n, 10)
+	case string:
+		return n
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -1,0 +1,417 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/lxzan/gws"
+)
+
+const (
+	sessionKeyConnID = "gw_conn_id"
+	sessionKeyProto  = "gw_protocol"
+	sessionKeyPlat   = "gw_platform"
+)
+
+// EventHandler 网关事件处理接口（由 bot 层实现）
+type EventHandler interface {
+	// OnMessage 收到标准化消息
+	OnMessage(msg *NormalizedMessage)
+}
+
+// Server 是反向 WebSocket 网关服务端，接受 Onebots/NapCat 的连接
+type Server struct {
+	cfg      *ListenConfig
+	hub      *Hub
+	handler  EventHandler
+	upgrader *gws.Upgrader
+	connSeq  atomic.Int64 // 连接 ID 递增序列
+	httpSrv  *http.Server // HTTP 服务（用于优雅关闭）
+}
+
+// ListenConfig 网关监听配置
+type ListenConfig struct {
+	ListenAddr  string // 监听地址，如 "0.0.0.0:8080"
+	AccessToken string // 鉴权 token（空则不鉴权）
+}
+
+// NewServer 创建网关服务端
+func NewServer(cfg *ListenConfig, handler EventHandler) *Server {
+	s := &Server{
+		cfg:     cfg,
+		hub:     NewHub(),
+		handler: handler,
+	}
+	s.upgrader = gws.NewUpgrader(s, &gws.ServerOption{
+		ParallelEnabled: true,
+		Recovery:        gws.Recovery,
+	})
+	return s
+}
+
+// Hub 返回连接管理中心（供 bot 层发送消息用）
+func (s *Server) Hub() *Hub {
+	return s.hub
+}
+
+// SetHandler 设置事件处理器（可在 NewServer 后设置，解决循环依赖）
+func (s *Server) SetHandler(handler EventHandler) {
+	s.handler = handler
+}
+
+// Run 启动网关 HTTP 服务，阻塞运行
+func (s *Server) Run() error {
+	mux := http.NewServeMux()
+	// 通用端点：通过 Sec-WebSocket-Protocol 头或查询参数自动检测协议
+	mux.HandleFunc("/onebot", s.handleUpgrade)
+	// OneBot 12 专用端点
+	mux.HandleFunc("/onebot/v12", s.handleUpgradeV12)
+	// OneBot 11 专用端点（NapCat 兼容）
+	mux.HandleFunc("/onebot/v11", s.handleUpgradeV11)
+
+	s.httpSrv = &http.Server{Addr: s.cfg.ListenAddr, Handler: mux}
+
+	log.Printf("gateway: 监听 %s", s.cfg.ListenAddr)
+	return s.httpSrv.ListenAndServe()
+}
+
+// Shutdown 优雅关闭：关闭所有 WS 连接，然后关闭 HTTP 监听器
+func (s *Server) Shutdown() {
+	// 关闭所有 WS 连接
+	for _, conn := range s.hub.All() {
+		conn.Socket.WriteClose(1000, []byte("server shutdown"))
+	}
+	// 关闭 HTTP 监听器（使 Run() 返回）
+	if s.httpSrv != nil {
+		_ = s.httpSrv.Close()
+	}
+}
+
+// ── HTTP 升级处理 ──
+
+func (s *Server) handleUpgrade(w http.ResponseWriter, r *http.Request) {
+	protocol, platform := detectProtocolAndPlatform(r)
+	s.doUpgrade(w, r, protocol, platform)
+}
+
+func (s *Server) handleUpgradeV12(w http.ResponseWriter, r *http.Request) {
+	_, platform := detectProtocolAndPlatform(r)
+	s.doUpgrade(w, r, ProtocolV12, platform)
+}
+
+func (s *Server) handleUpgradeV11(w http.ResponseWriter, r *http.Request) {
+	_, platform := detectProtocolAndPlatform(r)
+	s.doUpgrade(w, r, ProtocolV11, platform)
+}
+
+func (s *Server) doUpgrade(w http.ResponseWriter, r *http.Request, protocol Protocol, platform Platform) {
+	// 鉴权：支持 Authorization 头和 access_token 查询参数（OneBot 惯例）
+	if s.cfg.AccessToken != "" {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if token == "" {
+			token = r.URL.Query().Get("access_token")
+		}
+		if token != s.cfg.AccessToken {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	socket, err := s.upgrader.Upgrade(w, r)
+	if err != nil {
+		log.Printf("gateway: WS 升级失败: %v", err)
+		return
+	}
+
+	connID := strconv.FormatInt(s.connSeq.Add(1), 10)
+	conn := &Connection{
+		ID:       connID,
+		Platform: platform,
+		Protocol: protocol,
+		Socket:   socket,
+	}
+	// 将连接信息存入 socket 的 SessionStorage，供 OnClose/OnMessage 回调使用
+	session := socket.Session()
+	session.Store(sessionKeyConnID, connID)
+	session.Store(sessionKeyProto, string(protocol))
+	session.Store(sessionKeyPlat, string(platform))
+
+	s.hub.Register(conn)
+	log.Printf("gateway: 新连接 id=%s protocol=%s platform=%s remote=%s",
+		connID, protocol, platform, socket.RemoteAddr().String())
+
+	// 启动 ReadLoop 读取帧，否则 OnMessage/OnPing/OnClose 等回调不会被调用
+	go socket.ReadLoop()
+}
+
+// detectProtocolAndPlatform 从请求头和查询参数检测协议版本和平台
+func detectProtocolAndPlatform(r *http.Request) (Protocol, Platform) {
+	protocol := ProtocolV12 // 默认 OneBot 12
+	platform := PlatformQQ  // 默认 QQ
+
+	// 检查 Sec-WebSocket-Protocol 头
+	// OneBot 12: "12.xxx"，OneBot 11: "11.xxx"
+	wsProto := r.Header.Get("Sec-WebSocket-Protocol")
+	if wsProto != "" {
+		parts := strings.Split(wsProto, ".")
+		if len(parts) > 0 {
+			if parts[0] == "11" {
+				protocol = ProtocolV11
+			}
+			// 如果子协议包含平台信息，如 "12.go_onebot_wechat"
+			if len(parts) > 1 {
+				if strings.Contains(parts[1], "wechat") {
+					platform = PlatformWechat
+				} else if strings.Contains(parts[1], "telegram") {
+					platform = PlatformTelegram
+				} else if strings.Contains(parts[1], "napcat") {
+					platform = PlatformNapCat
+					protocol = ProtocolV11 // NapCat 必定是 OB11
+				}
+			}
+		}
+	}
+
+	// 查询参数覆盖（优先级最高）
+	if q := r.URL.Query().Get("protocol"); q != "" {
+		switch strings.ToLower(q) {
+		case "v11", "11", "onebot11":
+			protocol = ProtocolV11
+		case "v12", "12", "onebot12":
+			protocol = ProtocolV12
+		}
+	}
+	if q := r.URL.Query().Get("platform"); q != "" {
+		platform = Platform(q)
+	}
+
+	return protocol, platform
+}
+
+// ── gws.Event 实现 ──
+
+// OnOpen 连接建立
+func (s *Server) OnOpen(socket *gws.Conn) {
+	_ = socket.SetDeadline(time.Now().Add(60*time.Second + 30*time.Second))
+}
+
+// OnClose 连接关闭
+func (s *Server) OnClose(socket *gws.Conn, err error) {
+	connID, ok := loadSessionString(socket.Session(), sessionKeyConnID)
+	if !ok {
+		return
+	}
+	s.hub.Unregister(connID)
+	if err != nil {
+		log.Printf("gateway: 连接关闭 id=%s err=%v", connID, err)
+	} else {
+		log.Printf("gateway: 连接关闭 id=%s", connID)
+	}
+}
+
+// OnMessage 收到消息帧
+func (s *Server) OnMessage(socket *gws.Conn, message *gws.Message) {
+	// 收到任何帧都刷新 deadline，防止只发消息不发 ping 的客户端超时
+	_ = socket.SetDeadline(time.Now().Add(60*time.Second + 30*time.Second))
+
+	connID, ok := loadSessionString(socket.Session(), sessionKeyConnID)
+	if !ok {
+		return
+	}
+	conn, ok := s.hub.Get(connID)
+	if !ok {
+		return
+	}
+
+	// 只处理文本帧（OneBot 协议使用 JSON 文本）
+	if message.Opcode != gws.OpcodeText {
+		return
+	}
+
+	data := message.Data.Bytes()
+	log.Printf("gateway: 收到帧 conn=%s protocol=%s len=%d", connID, conn.Protocol, len(data))
+
+	// 根据协议版本解析事件
+	switch conn.Protocol {
+	case ProtocolV12:
+		s.handleV12Message(conn, data)
+	case ProtocolV11:
+		s.handleV11Message(conn, data)
+	default:
+		log.Printf("gateway: 未知协议 conn=%s protocol=%s", connID, conn.Protocol)
+	}
+}
+
+// OnPing 心跳
+func (s *Server) OnPing(socket *gws.Conn, payload []byte) {
+	_ = socket.SetDeadline(time.Now().Add(60*time.Second + 30*time.Second))
+}
+
+// OnPong 心跳回复
+func (s *Server) OnPong(socket *gws.Conn, payload []byte) {
+	_ = socket.SetDeadline(time.Now().Add(60*time.Second + 30*time.Second))
+}
+
+// ── 协议消息处理 ──
+
+func (s *Server) handleV12Message(conn *Connection, data []byte) {
+	// 区分事件（有 type）和 API 响应（有 echo/status）
+	tag := peekJSONTag(data)
+	if tag == "response" {
+		var resp ActionResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			log.Printf("gateway: OB12 响应解析失败 conn=%s err=%v", conn.ID, err)
+			return
+		}
+		if resp.RetCode != 0 || resp.Status == "failed" {
+			log.Printf("gateway: OB12 API 失败 conn=%s echo=%s status=%s retcode=%d msg=%s",
+				conn.ID, resp.Echo, resp.Status, resp.RetCode, resp.Message)
+		}
+		return
+	}
+
+	var evt EventV12
+	if err := json.Unmarshal(data, &evt); err != nil {
+		log.Printf("gateway: OB12 事件解析失败 conn=%s err=%v data=%s", conn.ID, err, string(data))
+		return
+	}
+
+	// 更新连接的 SelfID（首次收到事件时，并发安全）
+	if evt.SelfID != "" {
+		conn.SetSelfID(evt.SelfID)
+	}
+
+	// 元事件处理
+	if evt.Type == "meta" {
+		log.Printf("gateway: 元事件 conn=%s impl=%s platform=%s self_id=%s",
+			conn.ID, evt.Impl, evt.Platform, evt.SelfID)
+		if evt.Impl != "" {
+			conn.SetImpl(evt.Impl)
+		}
+		return
+	}
+
+	// 标准化消息事件
+	msg := NormalizeV12(conn.ID, &evt, conn.Platform)
+	if msg == nil {
+		return // 非消息事件，暂不处理
+	}
+
+	log.Printf("gateway: OB12 消息 conn=%s user=%s group=%s is_group=%v content_len=%d",
+		conn.ID, msg.UserID, msg.GroupID, msg.IsGroup, len(msg.Content))
+
+	if s.handler != nil {
+		s.handler.OnMessage(msg)
+	} else {
+		log.Printf("gateway: handler 未设置，消息被丢弃 conn=%s", conn.ID)
+	}
+}
+
+func (s *Server) handleV11Message(conn *Connection, data []byte) {
+	// 区分事件（有 post_type）和 API 响应（有 echo/status）
+	tag := peekJSONTag(data)
+	if tag == "response" {
+		var resp ActionResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			log.Printf("gateway: OB11 响应解析失败 conn=%s err=%v", conn.ID, err)
+			return
+		}
+		// 仅当响应失败时打印警告
+		if resp.RetCode != 0 || resp.Status == "failed" {
+			log.Printf("gateway: OB11 API 失败 conn=%s echo=%s status=%s retcode=%d msg=%s",
+				conn.ID, resp.Echo, resp.Status, resp.RetCode, resp.Message)
+		}
+		return
+	}
+
+	var evt EventV11
+	if err := json.Unmarshal(data, &evt); err != nil {
+		log.Printf("gateway: OB11 事件解析失败 conn=%s err=%v data=%s", conn.ID, err, string(data))
+		return
+	}
+
+	// 更新连接的 SelfID（并发安全）
+	if evt.SelfID != 0 {
+		conn.SetSelfID(strconv.FormatInt(evt.SelfID, 10))
+	}
+
+	// 元事件处理
+	if evt.PostType == "meta_event" {
+		log.Printf("gateway: 元事件 conn=%s self_id=%d", conn.ID, evt.SelfID)
+		return
+	}
+
+	// 标准化消息事件
+	msg := NormalizeV11(conn.ID, &evt, conn.Platform)
+	if msg == nil {
+		log.Printf("gateway: OB11 非消息事件 conn=%s post_type=%s", conn.ID, evt.PostType)
+		return
+	}
+
+	log.Printf("gateway: OB11 消息 conn=%s user=%s group=%s is_group=%v content_len=%d",
+		conn.ID, msg.UserID, msg.GroupID, msg.IsGroup, len(msg.Content))
+
+	if s.handler != nil {
+		s.handler.OnMessage(msg)
+	} else {
+		log.Printf("gateway: handler 未设置，消息被丢弃 conn=%s", conn.ID)
+	}
+}
+
+// ── JSON 帧分类 ──
+
+// peekJSONTag 轻量检测 JSON 帧类型：
+//   - "event"：有 post_type（OB11）或 type（OB12）= 事件（优先级最高）
+//   - "response"：有 echo 或 status（且非事件）= API 响应
+//   - ""：无法识别的 JSON
+//
+// 注意：事件优先检测，因为 OB11 meta_event.heartbeat 也有 status 字段（对象），
+// 但真正的 OneBot API 响应中 status 是字符串 "ok"/"failed"。
+func peekJSONTag(data []byte) string {
+	peek := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &peek); err != nil {
+		return ""
+	}
+	// 事件标记优先（OB11 post_type / OB12 type）
+	if _, ok := peek["post_type"]; ok {
+		return "event"
+	}
+	if _, ok := peek["type"]; ok {
+		return "event"
+	}
+	// API 响应标记
+	if _, ok := peek["echo"]; ok {
+		return "response"
+	}
+	if _, ok := peek["status"]; ok {
+		return "response"
+	}
+	return ""
+}
+
+// ── 写入辅助 ──
+
+// writeJSON 通过 WS 连接发送 JSON 数据
+func writeJSON(socket *gws.Conn, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("gateway: JSON 编码失败: %w", err)
+	}
+	return socket.WriteMessage(gws.OpcodeText, data)
+}
+
+// loadSessionString 从 SessionStorage 读取字符串值
+func loadSessionString(ss gws.SessionStorage, key string) (string, bool) {
+	val, ok := ss.Load(key)
+	if !ok {
+		return "", false
+	}
+	s, ok := val.(string)
+	return s, ok
+}

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -4,9 +4,10 @@ import "time"
 
 // User 对应 users 表
 type User struct {
-	ID        int64     `json:"id"          gorm:"primaryKey;autoIncrement;comment:用户ID"`
-	QQID      int64     `json:"qq_id"       gorm:"uniqueIndex;not null;comment:QQ号"`
-	Nickname  string    `json:"nickname"    gorm:"size:255;comment:昵称"`
-	CreatedAt time.Time `json:"created_at"  gorm:"autoCreateTime;comment:创建时间"`
-	UpdatedAt time.Time `json:"updated_at"  gorm:"autoUpdateTime;comment:更新时间"`
+	ID             int64     `json:"id"               gorm:"primaryKey;autoIncrement;comment:用户ID"`
+	Platform       string    `json:"platform"         gorm:"uniqueIndex:idx_platform_user;not null;size:32;comment:平台标识"`
+	PlatformUserID string    `json:"platform_user_id" gorm:"uniqueIndex:idx_platform_user;not null;size:255;comment:平台用户ID"`
+	Nickname       string    `json:"nickname"         gorm:"size:255;comment:昵称"`
+	CreatedAt      time.Time `json:"created_at"       gorm:"autoCreateTime;comment:创建时间"`
+	UpdatedAt      time.Time `json:"updated_at"       gorm:"autoUpdateTime;comment:更新时间"`
 }

--- a/internal/plugin/access_control.go
+++ b/internal/plugin/access_control.go
@@ -71,7 +71,7 @@ type Authorizer interface {
 	ActionsFor(principal string) ([][]string, error)
 	ListActions() []string
 	ListRoles() []string
-	InitBuiltinPolicies(superUsers []int64) error
+	InitBuiltinPolicies(superUserPrincipals []string) error
 	IsKnownRole(role string) bool
 	IsKnownAction(action string) bool
 }
@@ -248,7 +248,8 @@ func (s *Service) IsKnownAction(action string) bool {
 }
 
 // InitBuiltinPolicies 幂等写入内置策略，并只在不存在 owner 时引导 SUPER_USERS。
-func (s *Service) InitBuiltinPolicies(superUsers []int64) error {
+// superUserPrincipals 格式为 user::<platform>::<platformUserID> 列表
+func (s *Service) InitBuiltinPolicies(superUserPrincipals []string) error {
 	for role, actions := range builtinRoleActions() {
 		for _, action := range actions {
 			hasPolicy, err := s.enforcer.HasPolicy(role, action)
@@ -281,8 +282,7 @@ func (s *Service) InitBuiltinPolicies(superUsers []int64) error {
 	if len(owners) != 0 {
 		return nil
 	}
-	for _, userID := range superUsers {
-		principal := UserPrincipal(userID)
+	for _, principal := range superUserPrincipals {
 		if _, err := s.enforcer.AddRoleForUser(principal, RoleBotOwner); err != nil {
 			return fmt.Errorf("引导 bot_owner %s: %w", principal, err)
 		}
@@ -357,4 +357,24 @@ func ValidatePrincipal(principal string) bool {
 	return strings.HasPrefix(principal, "user::") ||
 		strings.HasPrefix(principal, "plugin::") ||
 		strings.HasPrefix(principal, "system::")
+}
+
+// ParseSuperUsers 解析超级用户配置字符串为 principal 列表
+// 格式：qq:123456,wechat:wxid_xxx → [user::qq::123456, user::wechat::wxid_xxx]
+func ParseSuperUsers(superUsersStr string) []string {
+	if superUsersStr == "" {
+		return nil
+	}
+	var principals []string
+	for _, entry := range strings.Split(superUsersStr, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		parts := strings.SplitN(entry, ":", 2)
+		if len(parts) == 2 {
+			principals = append(principals, UserPrincipal(parts[0], parts[1]))
+		}
+	}
+	return principals
 }

--- a/internal/plugin/access_control_test.go
+++ b/internal/plugin/access_control_test.go
@@ -77,9 +77,9 @@ func (a *fakeAuthz) ActionsFor(principal string) ([][]string, error) {
 	}
 	return result, nil
 }
-func (a *fakeAuthz) ListActions() []string               { return allActions() }
-func (a *fakeAuthz) ListRoles() []string                 { return []string{RolePluginCommandBasic, RoleBotOwner} }
-func (a *fakeAuthz) InitBuiltinPolicies(_ []int64) error { return nil }
+func (a *fakeAuthz) ListActions() []string                { return allActions() }
+func (a *fakeAuthz) ListRoles() []string                  { return []string{RolePluginCommandBasic, RoleBotOwner} }
+func (a *fakeAuthz) InitBuiltinPolicies(_ []string) error { return nil }
 func (a *fakeAuthz) IsKnownRole(role string) bool {
 	return role == RolePluginCommandBasic || role == RoleBotOwner
 }

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -481,7 +481,7 @@ func (r *Registry) makeCommandHandler(p Plugin, cmd CommandDef) func(ctx *comman
 			extra["installation_id"] = wasmPlugin.InstallationID()
 		}
 		input := &conduit.InputMessage{
-			UserID:  fmt.Sprintf("%d", cmdCtx.UserID),
+			UserID:  cmdCtx.PlatformUserID,
 			GroupID: cmdCtx.GroupID,
 			Content: cmdCtx.Message,
 			IsGroup: cmdCtx.IsGroup,

--- a/internal/plugin/wasm_abi.go
+++ b/internal/plugin/wasm_abi.go
@@ -465,8 +465,9 @@ func PluginPrincipal(pluginID, installationID string) string {
 }
 
 // UserPrincipal 构造 Casbin 用户主体。
-func UserPrincipal(qqID int64) string {
-	return fmt.Sprintf("user::%d", qqID)
+// 格式：user::<platform>::<platformUserID>，如 user::qq::123456 或 user::wechat::wxid_xxx
+func UserPrincipal(platform, platformUserID string) string {
+	return "user::" + platform + "::" + platformUserID
 }
 
 // SystemPrincipal 构造 Casbin 系统主体。

--- a/internal/plugin/wasm_abi_test.go
+++ b/internal/plugin/wasm_abi_test.go
@@ -189,8 +189,8 @@ func TestPluginPrincipal(t *testing.T) {
 }
 
 func TestUserPrincipal(t *testing.T) {
-	if got := UserPrincipal(123); got != "user::123" {
-		t.Errorf("UserPrincipal(123) = %q", got)
+	if got := UserPrincipal("qq", "123"); got != "user::qq::123" {
+		t.Errorf("UserPrincipal(qq, 123) = %q", got)
 	}
 }
 

--- a/internal/plugin/wasm_command.go
+++ b/internal/plugin/wasm_command.go
@@ -26,7 +26,7 @@ func NewWasmInstallCommand(ctx context.Context, installer wasmInstaller) command
 				commandCtx.Reply(wasmInstallUsage)
 				return nil
 			}
-			installation, err := installer.Install(ctx, UserPrincipal(commandCtx.UserID), parts[2])
+			installation, err := installer.Install(ctx, UserPrincipal(commandCtx.Platform, commandCtx.PlatformUserID), parts[2])
 			if err != nil {
 				commandCtx.Reply(fmt.Sprintf("Wasm 插件安装失败：%v", err))
 				return nil

--- a/internal/plugin/wasm_command_test.go
+++ b/internal/plugin/wasm_command_test.go
@@ -31,9 +31,10 @@ func TestWasmInstallCommandRequiresDirectURL(t *testing.T) {
 	var reply string
 
 	if err := cmd.Handler(&command.Context{
-		UserID:  10001,
-		Message: "/插件 安装",
-		Reply:   func(message string) { reply = message },
+		Platform:       "qq",
+		PlatformUserID: "10001",
+		Message:        "/插件 安装",
+		Reply:          func(message string) { reply = message },
 	}); err != nil {
 		t.Fatalf("handle usage: %v", err)
 	}
@@ -55,16 +56,17 @@ func TestWasmInstallCommandInstallsRemoteBinary(t *testing.T) {
 	var reply string
 
 	if err := cmd.Handler(&command.Context{
-		UserID:  10001,
-		Message: "/插件 安装 https://github.com/example/project/releases/download/v1/signin.wasm",
-		Reply:   func(message string) { reply = message },
+		Platform:       "qq",
+		PlatformUserID: "10001",
+		Message:        "/插件 安装 https://github.com/example/project/releases/download/v1/signin.wasm",
+		Reply:          func(message string) { reply = message },
 	}); err != nil {
 		t.Fatalf("install remote Wasm: %v", err)
 	}
 	if installer.calls != 1 {
 		t.Fatalf("Install called %d times, want 1", installer.calls)
 	}
-	if installer.actor != UserPrincipal(10001) {
+	if installer.actor != UserPrincipal("qq", "10001") {
 		t.Fatalf("actor = %q", installer.actor)
 	}
 	if installer.sourceURL != "https://github.com/example/project/releases/download/v1/signin.wasm" {
@@ -81,9 +83,10 @@ func TestWasmInstallCommandReportsInstallFailure(t *testing.T) {
 	var reply string
 
 	if err := cmd.Handler(&command.Context{
-		UserID:  10002,
-		Message: "/插件 安装 https://plugins.example/plugin.wasm",
-		Reply:   func(message string) { reply = message },
+		Platform:       "qq",
+		PlatformUserID: "10002",
+		Message:        "/插件 安装 https://plugins.example/plugin.wasm",
+		Reply:          func(message string) { reply = message },
 	}); err != nil {
 		t.Fatalf("handle failed installation: %v", err)
 	}

--- a/internal/plugin/wasm_e2e_integration_test.go
+++ b/internal/plugin/wasm_e2e_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -19,7 +20,7 @@ import (
 
 // TestSigninWasm_EndToEnd 覆盖示例 Wasm 的构建产物经数据库安装、加载和启动后，
 // 通过真实 Extism、PostgreSQL、Redis 与 Conduit 路由签到命令的完整链路。
-// QQ 回复边界使用闭包收集，以避免依赖 LLOneBot。
+// 消息回复边界使用闭包收集，以避免依赖具体 IM 平台。
 func TestSigninWasm_EndToEnd(t *testing.T) {
 	if os.Getenv("LANMEI_E2E") != "1" {
 		t.Skip("set LANMEI_E2E=1 to run Docker-backed Wasm E2E test")
@@ -55,12 +56,12 @@ func TestSigninWasm_EndToEnd(t *testing.T) {
 	}
 
 	const ownerID int64 = 900001
-	actor := UserPrincipal(ownerID)
+	actor := UserPrincipal("qq", strconv.FormatInt(ownerID, 10))
 	authorizer, err := NewService(inf.DB.Orm)
 	if err != nil {
 		t.Fatalf("create authorizer: %v", err)
 	}
-	if err := authorizer.InitBuiltinPolicies([]int64{ownerID}); err != nil {
+	if err := authorizer.InitBuiltinPolicies([]string{actor}); err != nil {
 		t.Fatalf("initialize authorization policies: %v", err)
 	}
 
@@ -130,9 +131,10 @@ func TestSigninWasm_EndToEnd(t *testing.T) {
 
 	replies := make([]string, 0, 2)
 	commandContext := &command.Context{
-		UserID:  10001,
-		GroupID: "e2e-group",
-		IsGroup: true,
+		Platform:       "qq",
+		PlatformUserID: "10001",
+		GroupID:        "e2e-group",
+		IsGroup:        true,
 		Reply: func(message string) {
 			replies = append(replies, message)
 		},

--- a/internal/plugin/wasm_host_test.go
+++ b/internal/plugin/wasm_host_test.go
@@ -31,11 +31,11 @@ func (a *fakeStateAuthorizer) RolesFor(_ string) ([]string, error) {
 func (a *fakeStateAuthorizer) ActionsFor(_ string) ([][]string, error) {
 	return nil, nil
 }
-func (a *fakeStateAuthorizer) ListActions() []string               { return nil }
-func (a *fakeStateAuthorizer) ListRoles() []string                 { return nil }
-func (a *fakeStateAuthorizer) InitBuiltinPolicies(_ []int64) error { return nil }
-func (a *fakeStateAuthorizer) IsKnownRole(_ string) bool           { return true }
-func (a *fakeStateAuthorizer) IsKnownAction(_ string) bool         { return true }
+func (a *fakeStateAuthorizer) ListActions() []string                { return nil }
+func (a *fakeStateAuthorizer) ListRoles() []string                  { return nil }
+func (a *fakeStateAuthorizer) InitBuiltinPolicies(_ []string) error { return nil }
+func (a *fakeStateAuthorizer) IsKnownRole(_ string) bool            { return true }
+func (a *fakeStateAuthorizer) IsKnownAction(_ string) bool          { return true }
 
 var _ Authorizer = (*fakeStateAuthorizer)(nil)
 

--- a/internal/plugin/wasm_integration_test.go
+++ b/internal/plugin/wasm_integration_test.go
@@ -86,10 +86,11 @@ func TestWasmCommandPass_ConduitIntegration(t *testing.T) {
 
 	var replies []string
 	cmdCtx := &command.Context{
-		UserID:  10001,
-		GroupID: "g1",
-		IsGroup: true,
-		Reply:   func(s string) { replies = append(replies, s) },
+		Platform:       "qq",
+		PlatformUserID: "10001",
+		GroupID:        "g1",
+		IsGroup:        true,
+		Reply:          func(s string) { replies = append(replies, s) },
 	}
 	if err := cmdSys.Process("/fakecmd", cmdCtx); err != nil {
 		t.Fatalf("Process error: %v", err)
@@ -128,10 +129,10 @@ func (m *mockAuthorizer) RolesFor(_ string) ([]string, error) {
 func (m *mockAuthorizer) ActionsFor(_ string) ([][]string, error) {
 	return [][]string{{RolePluginCommandBasic, ActionCommandHandle}}, nil
 }
-func (m *mockAuthorizer) ListActions() []string               { return allActions() }
-func (m *mockAuthorizer) ListRoles() []string                 { return []string{RolePluginCommandBasic} }
-func (m *mockAuthorizer) InitBuiltinPolicies(_ []int64) error { return nil }
-func (m *mockAuthorizer) IsKnownRole(role string) bool        { return role == RolePluginCommandBasic }
-func (m *mockAuthorizer) IsKnownAction(_ string) bool         { return true }
+func (m *mockAuthorizer) ListActions() []string                { return allActions() }
+func (m *mockAuthorizer) ListRoles() []string                  { return []string{RolePluginCommandBasic} }
+func (m *mockAuthorizer) InitBuiltinPolicies(_ []string) error { return nil }
+func (m *mockAuthorizer) IsKnownRole(role string) bool         { return role == RolePluginCommandBasic }
+func (m *mockAuthorizer) IsKnownAction(_ string) bool          { return true }
 
 var _ Authorizer = (*mockAuthorizer)(nil)

--- a/internal/plugin/wasm_pass.go
+++ b/internal/plugin/wasm_pass.go
@@ -101,9 +101,9 @@ func eventIDFromExtra(ctx *conduit.MessageContext) string {
 		return eventID
 	}
 	if messageID := stringExtra(ctx, "message_id"); messageID != "" {
-		return "qq-message-" + messageID
+		return "msg-" + messageID
 	}
-	return fmt.Sprintf("qq-event-%d", time.Now().UTC().UnixNano())
+	return fmt.Sprintf("evt-%d", time.Now().UTC().UnixNano())
 }
 
 func groupInfo(ctx *conduit.MessageContext) *GroupInfo {


### PR DESCRIPTION
- 新增网关层，基于lxzan/gws实现反向WS服务端，支持OneBot12/11协议
- 添加Onebots/NapCat设施，分别用于处理跨平台/NTQQ的消息
- 替换原有ZeroBot依赖，改为通过网关接收来自Onebots/NapCat的消息
- 重构用户模型和数据库模型，从单QQID改为(platform, platform_user_id)跨平台标识
- 更新配置系统，支持网关监听、鉴权配置，超级用户格式改为platform:user_id