### PR TITLE
feat: 多路召回与插件记忆防污染

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -414,6 +414,6 @@ erDiagram
 - [x] Command 管线优化（CommandRouterPass + ExecuteCommandPass 分离）
 - [x] WIT 接口定义（schema/plugin/lanmei-plugin.wit，含 db/http Host Functions）
 - [x] LOD 记忆压缩（L0 原文 → L1 摘要 → L2 主题）
-- [ ] 多路召回（向量 + 关键词 + 时间）
+- [x] 多路召回（向量 + 关键词 + 时间，memory.MultiRetriever 加权合并）
 - [ ] 签到记录表
 - [ ] 状态面板前端

--- a/internal/ai/chat.go
+++ b/internal/ai/chat.go
@@ -37,6 +37,7 @@ type ChatService struct {
 	client     llm.LLMClient
 	embedder   embedding.Embedder
 	memory     memory.MemoryStore
+	retriever  *memory.MultiRetriever // 多路召回合并器（为 nil 时降级为单一向量召回）
 	db         *database.DB
 	compressor *Compressor
 	toolReg    *tool.Registry
@@ -47,12 +48,13 @@ type ChatService struct {
 // NewChatService 创建对话服务
 func NewChatService(client llm.LLMClient, emb embedding.Embedder, mem memory.MemoryStore, db *database.DB, toolReg *tool.Registry, logger *zap.Logger) *ChatService {
 	svc := &ChatService{
-		client:   client,
-		embedder: emb,
-		memory:   mem,
-		db:       db,
-		toolReg:  toolReg,
-		logger:   logger,
+		client:    client,
+		embedder:  emb,
+		memory:    mem,
+		retriever: memory.NewMultiRetriever(mem, memory.DefaultRecallWeight),
+		db:        db,
+		toolReg:   toolReg,
+		logger:    logger,
 	}
 	// 压缩器依赖 ChatService 的各组件
 	if client != nil {
@@ -189,7 +191,7 @@ func (s *ChatService) assembleContext(ctx context.Context, req *llm.ChatRequest)
 		})
 	}
 
-	// ── RAG 检索长期记忆 ──
+	// ── RAG 检索长期记忆（多路召回）──
 	if queryVec == nil && s.embedder != nil {
 		queryVec, err = s.embedder.Embed(ctx, lastMsg.Content)
 		if err != nil {
@@ -197,17 +199,27 @@ func (s *ChatService) assembleContext(ctx context.Context, req *llm.ChatRequest)
 			err = nil // 嵌入失败不中断流程
 		}
 	}
-	if queryVec != nil && s.memory != nil {
-		memories, retrieveErr := s.memory.Retrieve(ctx, queryVec, req.UserID, 5)
+	var memories []*memory.Memory
+	if s.retriever != nil {
+		// 多路召回：向量 + 关键词 + 时间
+		var retrieveErr error
+		memories, retrieveErr = s.retriever.Retrieve(ctx, queryVec, lastMsg.Content, req.UserID, 5)
+		if retrieveErr != nil {
+			s.logger.Error("ai: multi-retrieve memory failed", zap.Error(retrieveErr))
+		}
+	} else if queryVec != nil && s.memory != nil {
+		// 降级：仅向量召回
+		var retrieveErr error
+		memories, retrieveErr = s.memory.Retrieve(ctx, queryVec, req.UserID, 5)
 		if retrieveErr != nil {
 			s.logger.Error("ai: retrieve memory failed", zap.Error(retrieveErr))
 		}
-		if ragCtx := BuildRAGContext(memories); ragCtx != "" {
-			msgs = append(msgs, llm.Message{
-				Role:    llm.RoleSystem,
-				Content: "以下是与当前对话相关的记忆：\n" + ragCtx,
-			})
-		}
+	}
+	if ragCtx := BuildRAGContext(memories); ragCtx != "" {
+		msgs = append(msgs, llm.Message{
+			Role:    llm.RoleSystem,
+			Content: "以下是与当前对话相关的记忆：\n" + ragCtx,
+		})
 	}
 
 	// 追加用户请求消息（当前轮次）
@@ -269,7 +281,7 @@ func (s *ChatService) chatWithToolLoop(ctx context.Context, req *llm.ChatRequest
 	}
 
 	// 进入工具调用循环：LLM 生成 → 执行工具 → 回传结果 → 再次生成，直至完成
-	schemaMsgs, totalTokens, err := s.processToolCalls(ctx, chatModel, schemaMsgs)
+	schemaMsgs, totalTokens, invokedTools, err := s.processToolCalls(ctx, chatModel, schemaMsgs)
 	if err != nil {
 		return nil, fmt.Errorf("chat: tool call loop: %w", err)
 	}
@@ -293,8 +305,9 @@ func (s *ChatService) chatWithToolLoop(ctx context.Context, req *llm.ChatRequest
 	s.asyncStoreAndCompress(ctx, req.UserID, req.Messages[len(req.Messages)-1].Content, nil)
 
 	return &llm.ChatResponse{
-		Content:    finalContent,
-		TokensUsed: totalTokens,
+		Content:       finalContent,
+		TokensUsed:    totalTokens,
+		InvolvedTools: invokedTools,
 	}, nil
 }
 
@@ -327,13 +340,14 @@ func (s *ChatService) chatWithToolLoop(ctx context.Context, req *llm.ChatRequest
 //   - []*schema.Message: 包含所有中间轮次消息的完整消息列表
 //   - int: 累计消耗的 token 总量
 //   - error: LLM 调用失败时的错误
-func (s *ChatService) processToolCalls(ctx context.Context, chatModel model.BaseChatModel, msgs []*schema.Message) ([]*schema.Message, int, error) {
+func (s *ChatService) processToolCalls(ctx context.Context, chatModel model.BaseChatModel, msgs []*schema.Message) ([]*schema.Message, int, []string, error) {
 	totalTokens := 0
+	var invokedTools []string
 	for round := 0; round < maxToolCallRounds; round++ {
 		// 调用 LLM 生成回复（可能包含工具调用请求）
 		resp, err := chatModel.Generate(ctx, msgs)
 		if err != nil {
-			return msgs, totalTokens, err
+			return msgs, totalTokens, invokedTools, err
 		}
 		// 将 LLM 回复追加到消息列表，作为下一轮的上下文
 		msgs = append(msgs, resp)
@@ -345,7 +359,7 @@ func (s *ChatService) processToolCalls(ctx context.Context, chatModel model.Base
 
 		// 如果 LLM 没有请求任何工具调用，说明已经产出最终文本回复，循环结束
 		if len(resp.ToolCalls) == 0 {
-			return msgs, totalTokens, nil
+			return msgs, totalTokens, invokedTools, nil
 		}
 
 		// 逐个执行 LLM 请求的工具调用
@@ -363,10 +377,12 @@ func (s *ChatService) processToolCalls(ctx context.Context, chatModel model.Base
 				ToolCallID: tc.ID,
 				Content:    result,
 			})
+			// 记录实际调用的工具名
+			invokedTools = append(invokedTools, tc.Function.Name)
 		}
 	}
 	// 达到最大轮次限制，强制退出循环
-	return msgs, totalTokens, nil
+	return msgs, totalTokens, invokedTools, nil
 }
 
 // asyncStoreAndCompress 异步存记忆 + 触发压缩

--- a/internal/ai/compressor.go
+++ b/internal/ai/compressor.go
@@ -227,6 +227,12 @@ facts 规则：
 - 格式："用户喜欢猫"、"用户的猫叫小雪"、"用户提到贫血"
 - 每条事实不超过20字
 
+插件输出规则：
+- 标有 [插件:XXX] 的内容是工具生成的随机结果，不是真实事实
+- 压缩时只记录"用户请求了XXX"，不提取插件输出的具体内容
+- 例如：不要写"用户运势大吉"，应写"用户请求了算命"
+- 不要将插件随机结果当作真实事实写入 brief/detailed/facts
+
 注意：只输出 JSON，不要任何额外文字。`
 
 const clusterSystemPrompt = `你是一个记忆聚合引擎。你的任务是阅读多段对话摘要，聚合为一个主题。
@@ -266,7 +272,12 @@ func formatConversations(convs []*model.Conversation) string {
 		if c.Role == "assistant" {
 			role = "蓝妹"
 		}
-		s += fmt.Sprintf("%s: %s\n", role, c.Content)
+		// 插件来源的对话标注工具名，帮助压缩器区分真实对话与工具输出
+		if c.Source == model.SourcePlugin && c.PluginTag != "" {
+			s += fmt.Sprintf("%s: [插件:%s] %s\n", role, c.PluginTag, c.Content)
+		} else {
+			s += fmt.Sprintf("%s: %s\n", role, c.Content)
+		}
 	}
 	return s
 }

--- a/internal/ai/llm/client.go
+++ b/internal/ai/llm/client.go
@@ -34,9 +34,10 @@ type ChatRequest struct {
 
 // ChatResponse 是对话服务的返回
 type ChatResponse struct {
-	Content    string             `json:"content"`
-	TokensUsed int                `json:"tokens_used"`
-	ToolCalls  []*schema.ToolCall `json:"tool_calls,omitempty"` // LLM 返回的工具调用
+	Content       string             `json:"content"`
+	TokensUsed    int                `json:"tokens_used"`
+	ToolCalls     []*schema.ToolCall `json:"tool_calls,omitempty"`      // LLM 返回的工具调用
+	InvolvedTools []string           `json:"involved_tools,omitempty"`  // 本次对话中实际调用的工具名列表
 }
 
 // LLMClient 抽象大语言模型的对话能力。

--- a/internal/ai/memory/multi_retriever.go
+++ b/internal/ai/memory/multi_retriever.go
@@ -1,0 +1,107 @@
+package memory
+
+import (
+	"context"
+	"sort"
+)
+
+// RecallWeight 定义各召回通路的基础权重
+type RecallWeight struct {
+	Vector  float64 // 向量召回权重
+	Keyword float64 // 关键词召回权重
+	Time    float64 // 时间召回权重
+}
+
+// DefaultRecallWeight 默认权重配置：向量最高，关键词次之，时间最低
+var DefaultRecallWeight = RecallWeight{
+	Vector:  1.0,
+	Keyword: 0.8,
+	Time:    0.5,
+}
+
+// ScoredMemory 带分数的记忆，用于多路召回合并排序
+type ScoredMemory struct {
+	*Memory
+	Score float64
+}
+
+// MultiRetriever 多路召回合并器
+// 从向量、关键词、时间三条通路检索记忆，去重后按加权分数排序
+type MultiRetriever struct {
+	store   MemoryStore
+	weights RecallWeight
+}
+
+// NewMultiRetriever 创建多路召回合并器
+func NewMultiRetriever(store MemoryStore, weights RecallWeight) *MultiRetriever {
+	return &MultiRetriever{store: store, weights: weights}
+}
+
+// Retrieve 执行多路召回并合并结果
+// queryVec: 查询向量（向量召回），query: 查询文本（关键词召回），userID: 用户ID，limit: 最终返回数量
+func (r *MultiRetriever) Retrieve(ctx context.Context, queryVec []float32, query string, userID int64, limit int) ([]*Memory, error) {
+	scored := make(map[string]*ScoredMemory) // 按 ID 去重
+
+	// 通路1：向量召回
+	if queryVec != nil {
+		memories, err := r.store.Retrieve(ctx, queryVec, userID, limit)
+		if err == nil {
+			for i, m := range memories {
+				addScore(scored, m, r.weights.Vector*rankScore(i, len(memories)))
+			}
+		}
+	}
+
+	// 通路2：关键词召回
+	if query != "" {
+		memories, err := r.store.RetrieveByKeyword(ctx, query, userID, limit)
+		if err == nil {
+			for i, m := range memories {
+				addScore(scored, m, r.weights.Keyword*rankScore(i, len(memories)))
+			}
+		}
+	}
+
+	// 通路3：时间召回
+	memories, err := r.store.RetrieveByTime(ctx, userID, limit)
+	if err == nil {
+		for i, m := range memories {
+			addScore(scored, m, r.weights.Time*rankScore(i, len(memories)))
+		}
+	}
+
+	// 按分数降序排序
+	sorted := make([]*ScoredMemory, 0, len(scored))
+	for _, sm := range scored {
+		sorted = append(sorted, sm)
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Score > sorted[j].Score
+	})
+
+	// 取 top-N
+	if len(sorted) > limit {
+		sorted = sorted[:limit]
+	}
+
+	result := make([]*Memory, len(sorted))
+	for i, sm := range sorted {
+		result[i] = sm.Memory
+	}
+	return result, nil
+}
+
+// rankScore 根据在召回列表中的排名计算衰减分数
+// 排名越靠前分数越高：第1名=1.0，第2名≈0.5，第3名≈0.33，依此类推
+func rankScore(rank, total int) float64 {
+	return 1.0 / float64(rank+1)
+}
+
+// addScore 将记忆加入评分表，如果已存在则累加分数（多路命中加权）
+func addScore(scored map[string]*ScoredMemory, m *Memory, score float64) {
+	if existing, ok := scored[m.ID]; ok {
+		existing.Score += score // 多路命中，分数累加
+	} else {
+		scored[m.ID] = &ScoredMemory{Memory: m, Score: score}
+	}
+}

--- a/internal/ai/memory/store.go
+++ b/internal/ai/memory/store.go
@@ -16,8 +16,12 @@ type Memory struct {
 type MemoryStore interface {
 	// Store 存储一条记忆（含向量）
 	Store(ctx context.Context, mem *Memory) error
-	// Retrieve 根据查询向量检索最相关的 N 条记忆
+	// Retrieve 根据查询向量检索最相关的 N 条记忆（向量召回）
 	Retrieve(ctx context.Context, queryVec []float32, userID int64, limit int) ([]*Memory, error)
+	// RetrieveByKeyword 根据关键词全文搜索检索记忆（关键词召回）
+	RetrieveByKeyword(ctx context.Context, query string, userID int64, limit int) ([]*Memory, error)
+	// RetrieveByTime 根据时间倒序检索最近的 N 条记忆（时间召回）
+	RetrieveByTime(ctx context.Context, userID int64, limit int) ([]*Memory, error)
 	// Delete 删除指定记忆
 	Delete(ctx context.Context, id string) error
 }

--- a/internal/ai/stream.go
+++ b/internal/ai/stream.go
@@ -71,6 +71,7 @@ func (s *ChatService) chatStreamWithToolLoop(
 	schemaMsgs := llm.ToSchemaMessages(req.Messages)
 	segmenter := NewStreamSegmenter()
 	totalTokens := 0
+	var invokedTools []string
 
 	for round := 0; round < maxToolCallRounds; round++ {
 		reader, streamErr := chatModel.Stream(ctx, schemaMsgs)
@@ -132,6 +133,7 @@ func (s *ChatService) chatStreamWithToolLoop(
 					ToolCallID: tc.ID,
 					Content:    result,
 				})
+				invokedTools = append(invokedTools, tc.Function.Name)
 			}
 			continue // 下一轮
 		}
@@ -185,8 +187,9 @@ func (s *ChatService) chatStreamWithToolLoop(
 		s.asyncStoreAndCompress(ctx, req.UserID, lastMsgContent, queryVec)
 
 		return &llm.ChatResponse{
-			Content:    segmenter.FullText(),
-			TokensUsed: totalTokens,
+			Content:       segmenter.FullText(),
+			TokensUsed:    totalTokens,
+			InvolvedTools: invokedTools,
 		}, nil
 	}
 
@@ -194,8 +197,9 @@ func (s *ChatService) chatStreamWithToolLoop(
 	s.asyncStoreAndCompress(ctx, req.UserID, lastMsgContent, queryVec)
 
 	return &llm.ChatResponse{
-		Content:    segmenter.FullText(),
-		TokensUsed: totalTokens,
+		Content:       segmenter.FullText(),
+		TokensUsed:    totalTokens,
+		InvolvedTools: invokedTools,
 	}, nil
 }
 

--- a/internal/bot/bt_intent.go
+++ b/internal/bot/bt_intent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DaWesen/lanmei-dream/internal/ai/tool"
 	"github.com/DaWesen/lanmei-dream/internal/command"
 	"github.com/DaWesen/lanmei-dream/internal/database"
+	"github.com/DaWesen/lanmei-dream/internal/model"
 )
 
 // intentResultKey 存储意图分析结果的上下文键
@@ -97,7 +98,7 @@ func (p *IntentIgnorePass) Execute(ctx *conduit.MessageContext) error {
 	if err != nil {
 		return conduit.NewSoftError(fmt.Errorf("intent_ignore: get or create user: %w", err))
 	}
-	if err := p.DB.SaveConversation(ctx.Ctx, user.ID, "user", ctx.RawMsg); err != nil {
+	if err := p.DB.SaveConversation(ctx.Ctx, user.ID, "user", ctx.RawMsg, model.SourceChat, ""); err != nil {
 		return conduit.NewSoftError(fmt.Errorf("intent_ignore: save conversation: %w", err))
 	}
 	// 不生成任何回复 → 静默忽略

--- a/internal/bot/roleplay_stream.go
+++ b/internal/bot/roleplay_stream.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DaWesen/lanmei-dream/internal/ai"
 	"github.com/DaWesen/lanmei-dream/internal/ai/llm"
 	"github.com/DaWesen/lanmei-dream/internal/database"
+	"github.com/DaWesen/lanmei-dream/internal/model"
 )
 
 // streamTimeout 流式回复的最大持续时间。
@@ -117,10 +118,17 @@ func (p *RoleplayStreamPass) runStream(
 	// 保存对话记录（L0 原始记录，后续由 Compressor 自动压缩）
 	// 使用 context.Background() 因为 streamCtx 可能已接近超时
 	bgCtx := context.Background()
-	if saveErr := p.DB.SaveConversation(bgCtx, userID, "user", userMsg); saveErr != nil {
+	if saveErr := p.DB.SaveConversation(bgCtx, userID, "user", userMsg, model.SourceChat, ""); saveErr != nil {
 		p.Logger.Error("roleplay stream: save user conversation", zap.Error(saveErr))
 	}
-	if saveErr := p.DB.SaveConversation(bgCtx, userID, "assistant", resp.Content); saveErr != nil {
+	// 根据是否调用了工具决定 assistant 消息的来源标记
+	source := model.SourceChat
+	pluginTag := ""
+	if len(resp.InvolvedTools) > 0 {
+		source = model.SourcePlugin
+		pluginTag = resp.InvolvedTools[0] // 取首个工具名作为标签
+	}
+	if saveErr := p.DB.SaveConversation(bgCtx, userID, "assistant", resp.Content, source, pluginTag); saveErr != nil {
 		p.Logger.Error("roleplay stream: save assistant conversation", zap.Error(saveErr))
 	}
 }

--- a/internal/database/conversation.go
+++ b/internal/database/conversation.go
@@ -8,11 +8,14 @@ import (
 )
 
 // SaveConversation 存储一条对话记录
-func (db *DB) SaveConversation(ctx context.Context, userID int64, role, content string) error {
+// source: 来源标记（chat/plugin），pluginTag: 插件标识（source=plugin 时必填）
+func (db *DB) SaveConversation(ctx context.Context, userID int64, role, content string, source model.ConversationSource, pluginTag string) error {
 	c := model.Conversation{
-		UserID:  userID,
-		Role:    role,
-		Content: content,
+		UserID:    userID,
+		Role:      role,
+		Content:   content,
+		Source:    source,
+		PluginTag: pluginTag,
 	}
 	if err := db.Orm.WithContext(ctx).Create(&c).Error; err != nil {
 		return fmt.Errorf("save_conversation: %w", err)

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -33,5 +33,29 @@ func (db *DB) Migrate(ctx context.Context) error {
 	)
 	db.logger.Info("HNSW 向量索引已就绪")
 
+	// 创建 GIN 全文搜索索引（用于关键词召回）
+	db.Orm.WithContext(ctx).Exec(
+		"CREATE INDEX IF NOT EXISTS idx_memory_vectors_search_vec ON memory_vectors USING gin (search_vec)",
+	)
+	db.logger.Info("GIN 全文搜索索引已就绪")
+
+	// 创建触发器函数：INSERT/UPDATE 时自动从 content 生成 tsvector
+	// 使用 simple 配置（不分词，按空白切割），适合中文等非空格分词语言
+	db.Orm.WithContext(ctx).Exec(`
+CREATE OR REPLACE FUNCTION memory_vectors_search_vec_trigger() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vec := to_tsvector('simple', COALESCE(NEW.content, ''));
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql`)
+
+	// 幂等创建触发器（DROP IF EXISTS 再 CREATE，避免重复绑定）
+	db.Orm.WithContext(ctx).Exec(`DROP TRIGGER IF EXISTS trg_memory_vectors_search_vec ON memory_vectors`)
+	db.Orm.WithContext(ctx).Exec(`
+CREATE TRIGGER trg_memory_vectors_search_vec
+  BEFORE INSERT OR UPDATE OF content ON memory_vectors
+  FOR EACH ROW EXECUTE FUNCTION memory_vectors_search_vec_trigger()`)
+	db.logger.Info("全文搜索触发器已就绪")
+
 	return nil
 }

--- a/internal/infra/pgvector.go
+++ b/internal/infra/pgvector.go
@@ -49,16 +49,7 @@ func (s *PGVectorStore) Retrieve(ctx context.Context, queryVec []float32, userID
 		return nil, fmt.Errorf("pgvector retrieve: %w", err)
 	}
 
-	memories := make([]*memory.Memory, len(rows))
-	for i, row := range rows {
-		memories[i] = &memory.Memory{
-			ID:      strconv.FormatInt(row.ID, 10),
-			UserID:  row.UserID,
-			Content: row.Content,
-			Vector:  row.Embedding.Slice(),
-		}
-	}
-	return memories, nil
+	return rowsToMemories(rows), nil
 }
 
 // Delete 删除指定 ID 的记忆
@@ -68,6 +59,99 @@ func (s *PGVectorStore) Delete(ctx context.Context, id string) error {
 		return fmt.Errorf("invalid id %q: %w", id, err)
 	}
 	return s.orm.WithContext(ctx).Delete(&model.MemoryVector{}, pk).Error
+}
+
+// RetrieveByKeyword 根据关键词全文搜索检索记忆（关键词召回）
+// 使用 PostgreSQL tsvector 全文搜索，simple 配置按空白切割适合中文
+func (s *PGVectorStore) RetrieveByKeyword(ctx context.Context, query string, userID int64, limit int) ([]*memory.Memory, error) {
+	// 将查询文本转换为 tsquery：按空白分割，用 & (AND) 连接
+	tsQuery := toSimpleTSQuery(query)
+	if tsQuery == "" {
+		return nil, nil
+	}
+
+	var rows []model.MemoryVector
+	err := s.orm.WithContext(ctx).Raw(
+		"SELECT * FROM memory_vectors WHERE user_id = ? AND search_vec @@ to_tsquery('simple', ?) ORDER BY ts_rank(search_vec, to_tsquery('simple', ?)) DESC LIMIT ?",
+		userID, tsQuery, tsQuery, limit,
+	).Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("pgvector keyword retrieve: %w", err)
+	}
+
+	return rowsToMemories(rows), nil
+}
+
+// RetrieveByTime 根据时间倒序检索最近的 N 条记忆（时间召回）
+func (s *PGVectorStore) RetrieveByTime(ctx context.Context, userID int64, limit int) ([]*memory.Memory, error) {
+	var rows []model.MemoryVector
+	err := s.orm.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("created_at DESC").
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("pgvector time retrieve: %w", err)
+	}
+
+	return rowsToMemories(rows), nil
+}
+
+// toSimpleTSQuery 将自然语言查询转为 simple 配置的 tsquery
+// 按 Unicode 空白分割，用 & (AND) 连接各词项
+func toSimpleTSQuery(query string) string {
+	var parts []string
+	for _, w := range splitWhitespace(query) {
+		if w != "" {
+			parts = append(parts, w+"&")
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	result := parts[0]
+	for i := 1; i < len(parts); i++ {
+		result += " & " + parts[i]
+	}
+	return result
+}
+
+// splitWhitespace 按空白字符分割字符串（模拟 strings.Fields 但返回可遍历切片）
+func splitWhitespace(s string) []string {
+	var fields []string
+	var buf []rune
+	for _, r := range s {
+		if isWhitespace(r) {
+			if len(buf) > 0 {
+				fields = append(fields, string(buf))
+				buf = buf[:0]
+			}
+		} else {
+			buf = append(buf, r)
+		}
+	}
+	if len(buf) > 0 {
+		fields = append(fields, string(buf))
+	}
+	return fields
+}
+
+func isWhitespace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+}
+
+// rowsToMemories 将数据库行转换为 Memory 切片
+func rowsToMemories(rows []model.MemoryVector) []*memory.Memory {
+	memories := make([]*memory.Memory, len(rows))
+	for i, row := range rows {
+		memories[i] = &memory.Memory{
+			ID:      strconv.FormatInt(row.ID, 10),
+			UserID:  row.UserID,
+			Content: row.Content,
+			Vector:  row.Embedding.Slice(),
+		}
+	}
+	return memories
 }
 
 // formatVector 将 float32 切片格式化为 SQL 向量字面量 '[0.1,0.2,...]'

--- a/internal/model/conversation.go
+++ b/internal/model/conversation.go
@@ -2,11 +2,21 @@ package model
 
 import "time"
 
+// ConversationSource 标记对话来源，用于压缩器区分真实对话与插件输出
+type ConversationSource string
+
+const (
+	SourceChat   ConversationSource = "chat"   // 真实对话
+	SourcePlugin ConversationSource = "plugin" // 插件交互
+)
+
 // Conversation 对应 conversations 表，存储对话历史（L0 原始层）
 type Conversation struct {
-	ID        int64     `json:"id"         gorm:"primaryKey;autoIncrement;comment:对话ID"`
-	UserID    int64     `json:"user_id"    gorm:"index;not null;comment:用户ID"`
-	Role      string    `json:"role"       gorm:"size:20;not null;comment:角色(user/assistant)"`
-	Content   string    `json:"content"    gorm:"type:text;not null;comment:对话内容"`
-	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime;index:idx_conversations_created;comment:创建时间"`
+	ID        int64              `json:"id"         gorm:"primaryKey;autoIncrement;comment:对话ID"`
+	UserID    int64              `json:"user_id"    gorm:"index;not null;comment:用户ID"`
+	Role      string             `json:"role"       gorm:"size:20;not null;comment:角色(user/assistant)"`
+	Content   string             `json:"content"    gorm:"type:text;not null;comment:对话内容"`
+	Source    ConversationSource `json:"source"     gorm:"size:20;not null;default:'chat';comment:来源(chat/plugin)"`
+	PluginTag string             `json:"plugin_tag" gorm:"size:64;comment:插件标识(如 fortune)"`
+	CreatedAt time.Time          `json:"created_at" gorm:"autoCreateTime;index:idx_conversations_created;comment:创建时间"`
 }

--- a/internal/model/memory_vector.go
+++ b/internal/model/memory_vector.go
@@ -8,9 +8,10 @@ import (
 
 // MemoryVector 对应 memory_vectors 表，使用 pgvector 存储记忆向量
 type MemoryVector struct {
-	ID        int64           `json:"id"         gorm:"primaryKey;autoIncrement;comment:记忆ID"`
-	UserID    int64           `json:"user_id"    gorm:"index;not null;comment:用户ID"`
-	Content   string          `json:"content"    gorm:"type:text;not null;comment:记忆文本"`
-	Embedding pgvector.Vector `json:"embedding"  gorm:"type:vector(1024);not null;comment:嵌入向量"`
-	CreatedAt time.Time       `json:"created_at" gorm:"autoCreateTime;comment:创建时间"`
+	ID         int64           `json:"id"          gorm:"primaryKey;autoIncrement;comment:记忆ID"`
+	UserID     int64           `json:"user_id"     gorm:"index;not null;comment:用户ID"`
+	Content    string          `json:"content"     gorm:"type:text;not null;comment:记忆文本"`
+	Embedding  pgvector.Vector `json:"embedding"   gorm:"type:vector(1024);not null;comment:嵌入向量"`
+	SearchVec  string          `json:"search_vec"  gorm:"type:tsvector;comment:全文搜索向量"`
+	CreatedAt  time.Time       `json:"created_at"  gorm:"autoCreateTime;comment:创建时间"`
 }


### PR DESCRIPTION
## feat: 多路召回与插件记忆防污染

### 一、RAG 多路召回

向量 + 关键词(tsvector) + 时间三路检索，加权合并去重排序。

| 文件 | 改动 |
|------|------|
| `model/memory_vector.go` | 加 tsvector 字段 |
| `database/migrate.go` | 加 GIN 索引 + 触发器自动维护 tsvector |
| `ai/memory/store.go` | 接口加 `RetrieveByKeyword` + `RetrieveByTime` |
| `infra/pgvector.go` | 实现关键词召回和时间召回，提取公共转换函数 |
| `ai/memory/multi_retriever.go` | **新文件**，三路合并去重加权排序 |
| `ai/chat.go` | 接入 MultiRetriever，nil 时降级回单一向量 |

### 二、插件记忆防污染

标记对话来源，压缩器识别插件输出并跳过随机内容。

| 文件 | 改动 |
|------|------|
| `model/conversation.go` | 加 `Source`(chat/plugin) + `PluginTag` 字段 |
| `database/conversation.go` | `SaveConversation` 加 source + pluginTag 参数 |
| `ai/llm/client.go` | `ChatResponse` 加 `InvolvedTools` 字段 |
| `ai/chat.go` | `processToolCalls` 收集工具名，写入 InvolvedTools |
| `ai/stream.go` | 流式路径同步收集 InvolvedTools |
| `bot/bt_intent.go` | 适配新签名 |
| `bot/roleplay_stream.go` | 存 assistant 消息时根据 InvolvedTools 标记来源 |
| `ai/compressor.go` | 格式化时标注 `[插件:XXX]`，压缩 prompt 加插件规则 |