### PR TITLE
feat: 新增入群欢迎插件（QQ 事件接收与消费）

### DIFF
--- a/cmd/lanmei/main.go
+++ b/cmd/lanmei/main.go
@@ -188,6 +188,12 @@ func main() {
 		}
 	}
 
+	if _, wasmWelcomeLoaded := pluginReg.Get("welcome"); !wasmWelcomeLoaded {
+		if err := pluginReg.Register(bizplugin.NewWelcomePlugin(logger)); err != nil {
+			logger.Fatal("注册入群欢迎插件失败", zap.Error(err))
+		}
+	}
+
 	if err := pluginReg.InitPlugins(ctx); err != nil {
 		logger.Fatal("插件初始化失败", zap.Error(err))
 	}

--- a/internal/bizplugin/README.md
+++ b/internal/bizplugin/README.md
@@ -1,0 +1,182 @@
+# bizplugin 包 —— 业务插件
+
+## 职责
+
+存放蓝妹的 Go 内置业务插件。每个插件实现 `pluginpkg.Plugin` 接口（`Info` / `OnInit` / `OnStart` / `OnStop`），在 `OnInit` 中注册 Pass、Pipeline、行为树 Subtree 到 Conduit 引擎，由 `cmd/lanmei/main.go` 统一注册。
+
+## 插件列表
+
+| 插件 | 文件 | 类型 | 说明 |
+|------|------|------|------|
+| `signin` | signin.go | 命令类 | 每日签到，通过斜杠命令触发 |
+| `welcome` | welcome.go | **事件类（模范示例）** | 新人入群欢迎，消费 QQ 通知事件 |
+
+`welcome` 是**消费 QQ 事件的模范示例**——事件类插件均参照其结构开发。下文完整说明从上游事件接入到下游插件消费的链路。
+
+## QQ 事件类插件开发指南（从上游接入到下游消费）
+
+### 全链路总览
+
+```
+OneBot 事件（入群 / 戳一戳 / ...）
+  │  ① gateway 归一化（白名单映射，仅收支持的事件）
+  ▼
+NormalizedMessage（+ EventType / EventSubType / EventData）
+  │  ② bot.OnMessage 分流，事件信息写入黑板 Extra
+  ▼
+引擎 Submit → 行为树
+  │  ③ 插件子树（第一层，优先）← 事件类插件在这里消费
+  │     （未被插件接住的事件会继续滑向后继分支直至意图分析——因此事件插件必须存在）
+  ▼
+插件管线 → AppendOutput → makeEventCallback → 网关发回群
+```
+
+### 1. 上游：事件接收通道（gateway 层，一般无需改动）
+
+事件归一化已由 gateway 层完成，事件类插件**不需要**接触协议解析：
+
+- `internal/gateway/notice.go`：事件白名单映射（`mapNoticeV12/V11`）与字段提取（`noticeEventDataV12/V11`）
+- `internal/gateway/message.go`：`NormalizeV12/V11` 将通知事件解析为 `NormalizedMessage`（事件时 `Content` 为空、`EventType` 非空）
+- **新增事件类型**只需在 `notice.go` 的映射表加常量与映射条目（如 `group_decrease`、`poke`），结构无需改动
+
+### 2. 中游：事件写入黑板（bot 层，一般无需改动）
+
+`bot.OnMessage` 将事件三字段写入引擎黑板 `Extra`，键定义于 `internal/bot/passes.go`：
+
+| 键 | 类型 | 说明 |
+|---|---|---|
+| `bot.event.type` | string | 规范化事件类型，如 `group_increase`（空 = 普通消息）|
+| `bot.event.sub_type` | string | 事件子类型，如 `approve` / `invite` |
+| `bot.event.data` | map[string]any | 事件全字段（user_id / group_id / operator_id / sub_type 等）|
+
+事件消息由事件专用回调 `makeEventCallback` 处理：处理出错只记日志不回复；正常完成时遍历输出发送（插件的欢迎文案由此发出）。
+
+### 3. 下游：插件消费（本包，以 welcome 为模范示例）
+
+#### 3.1 结构（与 signin 模板一致）
+
+```go
+type WelcomePlugin struct { logger *zap.Logger }
+
+func (p *WelcomePlugin) Info() pluginpkg.PluginInfo {
+    return pluginpkg.PluginInfo{
+        ID: "welcome", Name: "入群欢迎", Description: "新人入群时发送欢迎消息",
+        Version: "1.0.0", SubtreeID: pluginpkg.SubtreeID("welcome"),
+        // 事件类插件通常没有 Commands / Tools
+    }
+}
+
+// OnInit 注册 Pass → Pipeline → Subtree，全部必须 Track
+func (p *WelcomePlugin) OnInit(ctx *pluginpkg.PluginContext) error { ... }
+
+func (p *WelcomePlugin) OnStart(*pluginpkg.PluginContext) error { return nil }
+func (p *WelcomePlugin) OnStop(*pluginpkg.PluginContext) error  { return nil }
+```
+
+#### 3.2 子树条件：直接读黑板事件键（不导包）
+
+事件类插件的子树条件判断"当前消息是否是我关心的事件"。按项目约定，插件**不依赖 bot / gateway 包**，直接以字符串键读取黑板 `Extra`：
+
+```go
+const eventKeyType = "bot.event.type" // 键定义见 internal/bot/passes.go
+
+// isGroupIncreaseEvent 判断当前消息是否为新人入群事件
+func isGroupIncreaseEvent(ctx *conduit.MessageContext) bool {
+    eventType, _ := ctx.Extra[eventKeyType].(string)
+    return eventType == "group_increase" // 规范化类型，见 gateway/notice.go
+}
+```
+
+#### 3.3 子树与管线注册（仿 signin 三步）
+
+```go
+// 1. 注册 Pass（业务逻辑）
+passID := pluginpkg.PassID("welcome", "welcome")
+ctx.Engine.RegisterPass(passID, &welcomePass{logger: p.logger})
+ctx.Registry.TrackPass("welcome", passID)
+
+// 2. 注册动态管线（通过 Pass ID 引用，支持热替换）
+pipelineID := pluginpkg.PipelineID("welcome", "main")
+ctx.Engine.RegisterPipeline(conduit.NewPipelineFromIDs(pipelineID, passID))
+ctx.Registry.TrackPipeline("welcome", pipelineID)
+
+// 3. 注册行为树子树（事件路由）
+subtree := conduit.NewSequence(
+    conduit.NewCondition(isGroupIncreaseEvent),
+    conduit.NewAction(pipelineID),
+)
+ctx.Engine.RegisterSubtree(pluginpkg.SubtreeID("welcome"), subtree)
+```
+
+#### 3.4 Pass：消费事件数据并输出
+
+```go
+func (pass *welcomePass) Execute(ctx *conduit.MessageContext) error {
+    // 从事件全字段读取数据（模范示例：记录入群者 / 拉人者）
+    eventData, _ := ctx.Extra["bot.event.data"].(map[string]any)
+    pass.logger.Info("welcome: 新人入群",
+        zap.Any("user_id", eventData["user_id"]),
+        zap.Any("operator_id", eventData["operator_id"]),
+        zap.Any("sub_type", eventData["sub_type"]),
+        zap.String("group_id", ctx.GroupID),
+    )
+
+    // 回复统一写入 AppendOutput，由引擎回调统一发送
+    conduit.AppendOutput(ctx, &conduit.Message{
+        UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+        Content: welcomeMessages[rand.IntN(len(welcomeMessages))],
+    })
+    return nil
+}
+```
+
+**为什么事件必须在插件子树消费**：插件子树挂在行为树 Selector 最前（优先级最高）。事件被插件接住后不会滑向后继分支——否则会落入意图分析，用空文本调 LLM 产生无关回复。
+
+### 4. 注册（cmd/lanmei/main.go）
+
+仿 signin 的 wasm 兜底模式：内置插件注册前先查 Registry 是否已被同名 wasm 插件占用。
+
+```go
+if _, wasmWelcomeLoaded := pluginReg.Get("welcome"); !wasmWelcomeLoaded {
+    if err := pluginReg.Register(bizplugin.NewWelcomePlugin(logger)); err != nil {
+        logger.Fatal("注册入群欢迎插件失败", zap.Error(err))
+    }
+}
+```
+
+### 5. 本地验证方法
+
+1. 起依赖：`docker compose up -d postgres redis`（等 PG healthy）
+2. 启动蓝妹（环境变量直接 export，配置不读 `.env` 文件）：
+
+```bash
+export LANMEI_DATABASE_URL='postgres://lanmei:lanmei@localhost:5432/lanmei?sslmode=disable'
+export LANMEI_REDIS_ADDR='localhost:6379'
+export LANMEI_BOT_GATEWAY_LISTEN_ADDR='127.0.0.1:8080'
+go run ./cmd/lanmei
+```
+
+3. 用 WebSocket 客户端（Node ≥22 原生 `WebSocket` 即可）连接 `ws://127.0.0.1:8080/onebot/v12`（或 `/onebot/v11`），模拟 OneBot 实现推送事件，观察回发动作：
+
+```json
+// v12 入群事件
+{"id":"evt-1","impl":"test","platform":"qq","self_id":"11111","time":1754700000,
+ "type":"notice","detail_type":"group.increase","sub_type":"approve",
+ "user_id":"22222","group_id":"33333","operator_id":"44444"}
+```
+
+4. 预期：收到 `send_message` 动作、消息为欢迎文案；插件日志出现 `welcome: 新人入群`。验证完 `docker compose down` 清理。
+
+## 硬性约定
+
+- 插件结构、注册顺序、Track 清理等规范详见 [PLUGIN_DEVELOPMENT.md](../../PLUGIN_DEVELOPMENT.md)（Go 内置插件章节）
+- 回复统一 `conduit.AppendOutput`，Pass 内禁止直接发送
+- 跨 Pass 传数据用 `conduit.Set/Get`，key 带插件前缀（如 `plugin.welcome.xxx`）
+- 事件键直接使用字符串字面量（键定义见 `internal/bot/passes.go`），**不 import bot / gateway 包**
+
+## 关键依赖
+
+- `github.com/zrurf/conduit` — 引擎、行为树、管线（`MessageContext.Extra` 即黑板）
+- `internal/gateway` — 事件归一化与事件键契约（`notice.go`、`message.go`）
+- `internal/plugin` — 插件接口与资源注册（`PluginContext` / `PassID` / `PipelineID` / `StoreKey`）
+- `internal/bot` — 事件写入黑板（`OnMessage` 分流、`makeEventCallback`、事件键定义）

--- a/internal/bizplugin/welcome.go
+++ b/internal/bizplugin/welcome.go
@@ -1,0 +1,148 @@
+package bizplugin
+
+import (
+	"fmt"
+	"math/rand/v2"
+
+	pluginpkg "github.com/DaWesen/lanmei-dream/internal/plugin"
+	"github.com/zrurf/conduit"
+	"go.uber.org/zap"
+)
+
+// ============================================================
+// WelcomePlugin 入群欢迎插件
+// ============================================================
+
+// WelcomePlugin 实现新人入群欢迎功能，是消费 QQ 通知事件的模范示例。
+//
+// 功能：
+//   - 新人入群（group_increase）时发送欢迎消息
+//   - 多条内置文案随机挑选（纯文本，不 @ 新人）
+//   - 所有群都欢迎，不做按群配置、不做防刷限流
+//
+// 行为树：
+//
+//	subtree.welcome → Sequence(IsGroupIncreaseEvent, Action("pipeline.plugin.welcome.main"))
+//
+// 管线（动态模式，支持运行时热替换）：
+//
+//	pipeline.plugin.welcome.main → [welcomePass]
+//
+// 事件信息读取：插件不依赖 bot/gateway 包，直接从黑板 Extra 读取事件键
+// （"bot.event.type" / "bot.event.data"，由 bot 层 OnMessage 写入）。
+type WelcomePlugin struct {
+	logger *zap.Logger
+}
+
+// NewWelcomePlugin 创建入群欢迎插件。
+func NewWelcomePlugin(logger *zap.Logger) *WelcomePlugin {
+	return &WelcomePlugin{logger: logger}
+}
+
+// Info 返回入群欢迎插件元信息。
+func (p *WelcomePlugin) Info() pluginpkg.PluginInfo {
+	return pluginpkg.PluginInfo{
+		ID:          "welcome",
+		Name:        "入群欢迎",
+		Description: "新人入群时发送欢迎消息",
+		Version:     "1.0.0",
+		SubtreeID:   pluginpkg.SubtreeID("welcome"),
+	}
+}
+
+// OnInit 初始化入群欢迎插件，注册 Pass、Pipeline 和 Subtree。
+func (p *WelcomePlugin) OnInit(ctx *pluginpkg.PluginContext) error {
+	// 注册 Pass（依赖直接注入 Pass 结构体）
+	passID := pluginpkg.PassID("welcome", "welcome")
+	pass := &welcomePass{logger: p.logger}
+
+	if err := ctx.Engine.RegisterPass(passID, pass); err != nil {
+		return fmt.Errorf("register welcome pass: %w", err)
+	}
+
+	// 跟踪 Pass，卸载时自动清理
+	ctx.Registry.TrackPass("welcome", passID)
+
+	// 注册动态管线（通过 Pass ID 引用，支持运行时热替换）
+	pipelineID := pluginpkg.PipelineID("welcome", "main")
+	pl := conduit.NewPipelineFromIDs(pipelineID, passID)
+	if err := ctx.Engine.RegisterPipeline(pl); err != nil {
+		return fmt.Errorf("register pipeline: %w", err)
+	}
+
+	// 跟踪 Pipeline，卸载时自动清理
+	ctx.Registry.TrackPipeline("welcome", pipelineID)
+
+	// 注册行为树子树：入群事件路由
+	subtree := conduit.NewSequence(
+		conduit.NewCondition(isGroupIncreaseEvent),
+		conduit.NewAction(pipelineID),
+	)
+	if err := ctx.Engine.RegisterSubtree(pluginpkg.SubtreeID("welcome"), subtree); err != nil {
+		return fmt.Errorf("register subtree: %w", err)
+	}
+
+	return nil
+}
+
+// OnStart 入群欢迎插件无需后台任务。
+func (p *WelcomePlugin) OnStart(_ *pluginpkg.PluginContext) error { return nil }
+
+// OnStop 入群欢迎插件无需清理资源。
+func (p *WelcomePlugin) OnStop(_ *pluginpkg.PluginContext) error { return nil }
+
+// ============================================================
+// 条件判断
+// ============================================================
+
+// 黑板事件键（由 bot 层 OnMessage 写入，键定义见 internal/bot/passes.go）。
+// 插件按"不导包"约定直接使用字符串字面量。
+const (
+	eventKeyType = "bot.event.type" // string 规范化事件类型
+	eventKeyData = "bot.event.data" // map[string]any 事件全字段
+)
+
+// groupIncreaseEventType 规范化入群事件类型（对应 gateway 包的 EventTypeGroupIncrease）。
+const groupIncreaseEventType = "group_increase"
+
+// isGroupIncreaseEvent 判断当前消息是否为新人入群事件。
+func isGroupIncreaseEvent(ctx *conduit.MessageContext) bool {
+	eventType, _ := ctx.Extra[eventKeyType].(string)
+	return eventType == groupIncreaseEventType
+}
+
+// ============================================================
+// Pass 实现
+// ============================================================
+
+// welcomeMessages 内置欢迎文案（随机挑选，纯文本、不带新人信息）
+var welcomeMessages = []string{
+	"欢迎新同学加入！ヽ(✿ﾟ▽ﾟ)ノ",
+	"新人驾到，撒花欢迎~",
+	"欢迎欢迎~ 新朋友来啦！",
+	"欢迎加入本群，一起愉快玩耍吧~",
+	"有新同学来了，掌声欢迎！",
+}
+
+// welcomePass 发送欢迎消息：随机挑选文案并输出
+type welcomePass struct {
+	logger *zap.Logger
+}
+
+func (pass *welcomePass) Execute(ctx *conduit.MessageContext) error {
+	// 模范示例：从事件数据读取入群者/拉人者/子类型，记录消费信息
+	eventData, _ := ctx.Extra[eventKeyData].(map[string]any)
+	pass.logger.Info("welcome: 新人入群",
+		zap.Any("user_id", eventData["user_id"]),
+		zap.Any("operator_id", eventData["operator_id"]),
+		zap.Any("sub_type", eventData["sub_type"]),
+		zap.String("group_id", ctx.GroupID),
+	)
+
+	content := welcomeMessages[rand.IntN(len(welcomeMessages))]
+	conduit.AppendOutput(ctx, &conduit.Message{
+		UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+		Content: content,
+	})
+	return nil
+}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -206,8 +206,11 @@ func (b *Bot) Run() {
 
 // OnMessage 实现 gateway.EventHandler 接口，将网关消息转为 Conduit 输入。
 // 使用异步 Submit + ResponseCallback，避免阻塞网关事件处理。
+//
+// 通知事件（EventType 非空）无文本内容，与普通消息分流：
+// 事件信息经 Extra 写入黑板供插件消费；事件不产生回复，出错也保持静默。
 func (b *Bot) OnMessage(msg *gateway.NormalizedMessage) {
-	if msg.Content == "" {
+	if msg.EventType == "" && msg.Content == "" {
 		return
 	}
 
@@ -223,13 +226,41 @@ func (b *Bot) OnMessage(msg *gateway.NormalizedMessage) {
 			KeyMessageID:      msg.MessageID,
 			KeyConnID:         msg.ConnID,
 			KeySelfID:         msg.SelfID,
+			KeyEventType:      msg.EventType,
+			KeyEventSubType:   msg.EventSubType,
+			KeyEventData:      msg.EventData,
 		},
 	}
-	input.ResponseCallback = b.makeResponseCallback(msg)
+	if msg.EventType != "" {
+		// 事件消息：出错也绝不向群里发消息（事件落空发"迷糊话术"是 bug）
+		input.ResponseCallback = b.makeEventCallback(msg)
+	} else {
+		input.ResponseCallback = b.makeResponseCallback(msg)
+	}
 
 	if err := b.engine.Submit(input); err != nil {
 		b.logger.Error("conduit: submit failed", zap.Error(err))
-		b.reply(msg, "蓝妹现在有点迷糊，稍后再试~")
+		if msg.EventType == "" {
+			b.reply(msg, "蓝妹现在有点迷糊，稍后再试~")
+		}
+	}
+}
+
+// makeEventCallback 构造通知事件专用回调：事件处理出错时只记日志、绝不回复；
+// 正常完成时遍历 Output 发送（供未来事件消费插件写入输出，如入群欢迎）。
+func (b *Bot) makeEventCallback(msg *gateway.NormalizedMessage) func(*conduit.MessageContext, error) {
+	return func(ctx *conduit.MessageContext, err error) {
+		if err != nil {
+			b.logger.Error("bot: event process failed",
+				zap.String("event", msg.EventType),
+				zap.String("group", msg.GroupID),
+				zap.Error(err),
+			)
+			return
+		}
+		for _, out := range ctx.Output {
+			b.reply(msg, out.Content)
+		}
 	}
 }
 

--- a/internal/bot/passes.go
+++ b/internal/bot/passes.go
@@ -20,6 +20,11 @@ const (
 	KeySelfID         = "self_id"          // string 机器人自身 ID
 	KeyIsSegment      = "bot.is_segment"   // bool 标记流式段落重入消息
 	KeyStreamChannel  = "bot.stream.ch"    // chan string 流式段落通道
+
+	// 通知事件键：普通消息下 EventType 为空串、EventData 为 nil
+	KeyEventType    = "bot.event.type"     // string 规范化事件类型（空=普通消息）
+	KeyEventSubType = "bot.event.sub_type" // string 事件子类型
+	KeyEventData    = "bot.event.data"     // map[string]any 事件全字段
 )
 
 // ── CommandPass：处理斜杠命令 ──

--- a/internal/gateway/event.go
+++ b/internal/gateway/event.go
@@ -37,6 +37,7 @@ type EventV12 struct {
 	SubType    string              `json:"sub_type"`
 	UserID     string              `json:"user_id,omitempty"`
 	GroupID    string              `json:"group_id,omitempty"`
+	OperatorID string              `json:"operator_id,omitempty"` // notice 操作者（如拉人入群者）
 	Message    []MessageSegmentV12 `json:"message,omitempty"`
 	AltMessage string              `json:"alt_message,omitempty"` // 纯文本表示
 }
@@ -51,11 +52,13 @@ type EventV11 struct {
 	Time        int64           `json:"time"`
 	SelfID      int64           `json:"self_id"`
 	PostType    string          `json:"post_type"`              // message / notice / request / meta_event
+	NoticeType  string          `json:"notice_type,omitempty"`  // notice 子类型（group_increase / group_decrease / ...）
 	MessageType string          `json:"message_type,omitempty"` // private / group
 	SubType     string          `json:"sub_type,omitempty"`
 	UserID      int64           `json:"user_id,omitempty"`
 	GroupID     int64           `json:"group_id,omitempty"`
-	Message     json.RawMessage `json:"message,omitempty"` // array of MessageSegmentV11 or string
+	OperatorID  int64           `json:"operator_id,omitempty"` // notice 操作者（如拉人入群者）
+	Message     json.RawMessage `json:"message,omitempty"`     // array of MessageSegmentV11 or string
 	RawMessage  string          `json:"raw_message,omitempty"`
 	Sender      SenderV11       `json:"sender,omitempty"`
 	// 消息 ID（NapCat 扩展）

--- a/internal/gateway/message.go
+++ b/internal/gateway/message.go
@@ -90,12 +90,18 @@ type NormalizedMessage struct {
 	SenderName string   // 发送者昵称
 	MessageID  string   // 消息 ID
 	ConnID     string   // 来源连接 ID（用于回复路由）
+
+	// 通知事件字段：空 EventType = 普通消息；非空 = 通知事件（此时 Content 为空）
+	EventType    string         // 规范化事件类型（见 notice.go）
+	EventSubType string         // 事件子类型（透传原始 sub_type，可为空）
+	EventData    map[string]any // 事件全字段（普通消息为 nil）
 }
 
 // NormalizeV12 将 OneBot 12 事件标准化为 NormalizedMessage
 func NormalizeV12(connID string, evt *EventV12, platform Platform) *NormalizedMessage {
 	if evt.Type != "message" {
-		return nil
+		// 通知事件：仅接收白名单内的事件类型（见 notice.go）
+		return normalizeNoticeV12(connID, evt, platform)
 	}
 
 	userID := evt.UserID
@@ -130,12 +136,15 @@ func NormalizeV12(connID string, evt *EventV12, platform Platform) *NormalizedMe
 // NormalizeV11 将 OneBot 11 事件标准化为 NormalizedMessage
 func NormalizeV11(connID string, evt *EventV11, platform Platform) *NormalizedMessage {
 	if evt.PostType != "message" {
-		return nil
+		// 通知事件：仅接收白名单内的事件类型（见 notice.go）
+		return normalizeNoticeV11(connID, evt, platform)
 	}
 
 	userID := strconv.FormatInt(evt.UserID, 10)
 	groupID := ""
-	isGroup := evt.MessageType == "group"
+	// 群聊判定：正常报文以 message_type 为准；group_id 非 0 时兜底判为群聊
+	//（防御 message_type 缺失的异常报文，notice 事件不经过此分支）
+	isGroup := evt.MessageType == "group" || evt.GroupID != 0
 	if isGroup {
 		groupID = strconv.FormatInt(evt.GroupID, 10)
 	}

--- a/internal/gateway/notice.go
+++ b/internal/gateway/notice.go
@@ -1,0 +1,141 @@
+package gateway
+
+import "strconv"
+
+// ── 规范化事件类型 ──
+//
+// 通知事件经 NormalizeV12/V11 归一化后的统一类型名（写入 NormalizedMessage.EventType）。
+// 目前仅支持"新人入群"（group_increase），后续新增事件类型时在此补充常量与映射即可。
+const (
+	EventTypeGroupIncrease = "group_increase" // 新人入群
+)
+
+// mapNoticeV12 将 OneBot 12 通知事件的 detail_type 映射为规范化事件类型。
+// 返回 (类型, 是否支持)；不支持的事件返回 ("", false)，由调用方丢弃。
+func mapNoticeV12(evt *EventV12) (string, bool) {
+	switch evt.DetailType {
+	case "group.increase":
+		return EventTypeGroupIncrease, true
+	}
+	return "", false
+}
+
+// mapNoticeV11 将 OneBot 11 通知事件的 notice_type 映射为规范化事件类型。
+// 返回 (类型, 是否支持)；不支持的事件返回 ("", false)，由调用方丢弃。
+func mapNoticeV11(evt *EventV11) (string, bool) {
+	switch evt.NoticeType {
+	case "group_increase":
+		return EventTypeGroupIncrease, true
+	}
+	return "", false
+}
+
+// normalizeNoticeV12 将 OneBot 12 通知事件标准化为 NormalizedMessage。
+// 由 NormalizeV12 在 Type != "message" 时调用；仅接收白名单内的事件（见 mapNoticeV12），
+// 白名单外的事件（request / meta / 其他 notice 类型）返回 nil。
+func normalizeNoticeV12(connID string, evt *EventV12, platform Platform) *NormalizedMessage {
+	if evt.Type != "notice" {
+		return nil
+	}
+	eventType, ok := mapNoticeV12(evt)
+	if !ok {
+		return nil
+	}
+	// 机器人自入群（被拉进自己的群），丢弃
+	if eventType == EventTypeGroupIncrease && evt.UserID == evt.SelfID {
+		return nil
+	}
+
+	// 如果事件平台字段有效，优先使用事件中的平台标识
+	p := platform
+	if evt.Platform != "" {
+		p = Platform(evt.Platform)
+	}
+
+	return &NormalizedMessage{
+		Platform:     p,
+		Protocol:     ProtocolV12,
+		SelfID:       evt.SelfID,
+		UserID:       evt.UserID,
+		GroupID:      evt.GroupID,
+		IsGroup:      evt.GroupID != "",
+		EventType:    eventType,
+		EventSubType: evt.SubType,
+		EventData:    noticeEventDataV12(evt),
+		ConnID:       connID,
+	}
+}
+
+// normalizeNoticeV11 将 OneBot 11 通知事件标准化为 NormalizedMessage。
+// 由 NormalizeV11 在 PostType != "message" 时调用；仅接收白名单内的事件（见 mapNoticeV11），
+// 白名单外的事件（request / meta / 其他 notice 类型）返回 nil。
+func normalizeNoticeV11(connID string, evt *EventV11, platform Platform) *NormalizedMessage {
+	if evt.PostType != "notice" {
+		return nil
+	}
+	eventType, ok := mapNoticeV11(evt)
+	if !ok {
+		return nil
+	}
+	// 机器人自入群（被拉进自己的群），丢弃
+	if eventType == EventTypeGroupIncrease && evt.UserID == evt.SelfID {
+		return nil
+	}
+
+	return &NormalizedMessage{
+		Platform:     platform,
+		Protocol:     ProtocolV11,
+		SelfID:       strconv.FormatInt(evt.SelfID, 10),
+		UserID:       formatID(evt.UserID),
+		GroupID:      formatID(evt.GroupID),
+		IsGroup:      evt.GroupID != 0,
+		EventType:    eventType,
+		EventSubType: evt.SubType,
+		EventData:    noticeEventDataV11(evt),
+		ConnID:       connID,
+	}
+}
+
+// noticeEventDataV12 提取 OneBot 12 事件特有业务字段（仅填充非空字段）。
+func noticeEventDataV12(evt *EventV12) map[string]any {
+	data := make(map[string]any)
+	if evt.UserID != "" {
+		data["user_id"] = evt.UserID // 事件主体（入群者）
+	}
+	if evt.GroupID != "" {
+		data["group_id"] = evt.GroupID
+	}
+	if evt.OperatorID != "" {
+		data["operator_id"] = evt.OperatorID // 操作者（拉人入群者）
+	}
+	if evt.SubType != "" {
+		data["sub_type"] = evt.SubType // approve / invite
+	}
+	return data
+}
+
+// noticeEventDataV11 提取 OneBot 11 事件特有业务字段（数字 ID 转字符串，缺字段给空串）。
+func noticeEventDataV11(evt *EventV11) map[string]any {
+	data := make(map[string]any)
+	if v := formatID(evt.UserID); v != "" {
+		data["user_id"] = v // 事件主体（入群者）
+	}
+	if v := formatID(evt.GroupID); v != "" {
+		data["group_id"] = v
+	}
+	if v := formatID(evt.OperatorID); v != "" {
+		data["operator_id"] = v // 操作者（拉人入群者）
+	}
+	if evt.SubType != "" {
+		data["sub_type"] = evt.SubType // approve / invite
+	}
+	return data
+}
+
+// formatID 将 OneBot 11 的数字 ID 转为字符串；0（缺字段）返回空串，避免出现 "0" 误导下游。
+func formatID(v int64) string {
+	if v == 0 {
+		return ""
+	}
+	return strconv.FormatInt(v, 10)
+}


### PR DESCRIPTION
新增 QQ 事件接收通道与入群欢迎插件，作为消费 QQ 事件的模范示例：

1. 新增入群事件（group_increase）接收：gateway 归一化 OneBot 12/11 通知事件进 NormalizedMessage（EventType/EventSubType/EventData），白名单映射、自入群排除、v11 群聊判定修复
2. bot.OnMessage 分流：事件信息写入黑板 Extra（bot.event.type / sub_type / data），事件处理错误静默不回复
3. 新增入群欢迎插件 welcome：严格仿照 signin 模板，行为树第一层消费事件，多条内置文案随机欢迎新人（纯文本、不带新人信息）
4. 新增 internal/bizplugin/README.md：QQ 事件类插件开发指南（从上游接入到下游消费全链路）
5. 已本地实测验证：docker 起依赖 + Node WebSocket 模拟 OneBot 推送 v12/v11 入群事件，均收到随机欢迎文案；白名单外事件静默丢弃