### PR TITLE
feat:上一个蓝妹的部分插件实现

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,11 @@ LANMEI_AI_EMBEDDING_MODEL=text-embedding-3-small
 # 向量维度（需与 Embedding 模型匹配，text-embedding-3-small=1536）
 LANMEI_AI_EMBEDDING_DIM=1536
 
+# ── 网易云点歌插件 ──
+# 网易云音乐 API 服务地址（ncm-api，如 moefurina/ncm-api 镜像）。
+# 为空时 /music 点歌功能不可用
+LANMEI_PLUGIN_NCM_URL=
+
 # ── PostgreSQL 容器 ──
 # POSTGRES_USER=lanmei
 # POSTGRES_PASSWORD=lanmei

--- a/cmd/lanmei/main.go
+++ b/cmd/lanmei/main.go
@@ -228,6 +228,7 @@ func main() {
 	// 替代在 main.go 硬编码 if 块逐个注册的写法：启停由配置文件控制；
 	// 内置插件与 Wasm 插件同走一个注册表，同名插件已由 Wasm 加载时自动跳过，避免 ID 冲突。
 	bizReg := bizplugin.NewBusinessRegistry(&cfg.Plugin.Builtins, pluginReg, inf.DB, logger)
+	bizReg.SetNCMURL(cfg.Plugin.NCMURL)
 	if err := bizReg.RegisterBuiltins(); err != nil {
 		logger.Fatal("内置业务插件注册失败", zap.Error(err))
 	}

--- a/config/config.toml
+++ b/config/config.toml
@@ -31,12 +31,20 @@ max_backups = 10
 
 [plugin]
 root_dir = "./data/plugins"
+# 网易云点歌 API 服务地址（ncm-api），为空时点歌插件不可用
+ncm_url = ""
 
 # 内置业务插件开关（配置驱动注册，无需改代码即可启停）
 # 若同名插件已由 Wasm 动态加载，内置注册自动跳过，避免重复
 [plugin.builtins]
-signin = true    # 签到插件
-welcome = true   # 入群欢迎插件
+signin = true      # 签到插件
+welcome = true     # 入群欢迎插件
+rank = true        # 签到积分排行榜插件
+cat = true         # 猫猫图片插件
+balogo = true      # 蔚蓝档案 LOGO 插件
+ping = true        # 连通性测试插件
+github_card = true # GitHub 链接卡片插件
+music = true       # 网易云点歌插件
 
 # ============================================
 # Prompt 系统路径声明

--- a/internal/bizplugin/balogo.go
+++ b/internal/bizplugin/balogo.go
@@ -1,0 +1,209 @@
+package bizplugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	pluginpkg "github.com/DaWesen/lanmei-dream/internal/plugin"
+	"github.com/zrurf/conduit"
+)
+
+// ============================================================
+// BaLogoPlugin 蔚蓝档案风格LOGO插件
+// ============================================================
+
+// BaLogoPlugin 生成蔚蓝档案（Blue Archive）风格LOGO图片。
+//
+// 功能：
+//   - 触发命令：/balogo 左文字 右文字
+//   - 通过外部服务 balogo.huankong.top 代理生成 BA 风格 LOGO 图片
+//   - 参数格式错误时回复用法提示
+//
+// 行为树：
+//
+//	subtree.balogo → Sequence(IsBaLogoCommand, Action("pipeline.plugin.balogo"))
+//
+// 管线：
+//
+//	pipeline.plugin.balogo → [executePass, replyPass]
+type BaLogoPlugin struct{}
+
+// NewBaLogoPlugin 创建 BA-LOGO 插件。
+func NewBaLogoPlugin() *BaLogoPlugin {
+	return &BaLogoPlugin{}
+}
+
+// baLogoURL 外部 BA-LOGO 生成服务地址（与上游 LanMei 一致）。
+// textL/textR 分别对应左右两部分文字，由服务端渲染成图片。
+var baLogoURL = "https://balogo.huankong.top/?textL=%v&textR=%v"
+
+// Info 返回 BA-LOGO 插件元信息。
+func (p *BaLogoPlugin) Info() pluginpkg.PluginInfo {
+	return pluginpkg.PluginInfo{
+		ID:          "balogo",
+		Name:        "BA-LOGO",
+		Description: "生成蔚蓝档案风格LOGO",
+		Version:     "1.0.0",
+		Commands: []pluginpkg.CommandDef{
+			{Name: "balogo", Description: "生成蔚蓝档案风格LOGO，格式：/balogo 左文字 右文字"},
+		},
+		SubtreeID: pluginpkg.SubtreeID("balogo"),
+		Tools: []pluginpkg.ToolDef{
+			{
+				Name:        "balogo_generate",
+				Description: "生成蔚蓝档案风格LOGO图片，需提供左文字和右文字两个参数，返回图片URL",
+				Handler:     p.toolBaLogoGenerate,
+			},
+		},
+	}
+}
+
+// OnInit 初始化 BA-LOGO 插件，注册 Pass、Pipeline 和 Subtree。
+func (p *BaLogoPlugin) OnInit(ctx *pluginpkg.PluginContext) error {
+	// 注册 Pass
+	executePassID := pluginpkg.PassID("balogo", "execute")
+	replyPassID := pluginpkg.PassID("balogo", "reply")
+
+	executePass := &balogoExecutePass{}
+	replyPass := &balogoReplyPass{}
+
+	if err := ctx.Engine.RegisterPass(executePassID, executePass); err != nil {
+		return fmt.Errorf("register execute pass: %w", err)
+	}
+	if err := ctx.Engine.RegisterPass(replyPassID, replyPass); err != nil {
+		return fmt.Errorf("register reply pass: %w", err)
+	}
+
+	// 跟踪 Pass
+	ctx.Registry.TrackPass("balogo", executePassID)
+	ctx.Registry.TrackPass("balogo", replyPassID)
+
+	// 注册管线
+	pipelineID := pluginpkg.PipelineID("balogo", "main")
+	pl := conduit.NewPipelineFromIDs(
+		pipelineID,
+		executePassID,
+		replyPassID,
+	)
+	if err := ctx.Engine.RegisterPipeline(pl); err != nil {
+		return fmt.Errorf("register pipeline: %w", err)
+	}
+
+	// 跟踪 Pipeline
+	ctx.Registry.TrackPipeline("balogo", pipelineID)
+
+	// 注册行为树子树
+	subtree := conduit.NewSequence(
+		conduit.NewCondition(isBaLogoCommand),
+		conduit.NewAction(pipelineID),
+	)
+	if err := ctx.Engine.RegisterSubtree(pluginpkg.SubtreeID("balogo"), subtree); err != nil {
+		return fmt.Errorf("register subtree: %w", err)
+	}
+
+	return nil
+}
+
+// OnStart BA-LOGO 插件无需后台任务。
+func (p *BaLogoPlugin) OnStart(_ *pluginpkg.PluginContext) error { return nil }
+
+// OnStop BA-LOGO 插件无需清理资源。
+func (p *BaLogoPlugin) OnStop(_ *pluginpkg.PluginContext) error { return nil }
+
+// ============================================================
+// 条件判断
+// ============================================================
+
+// isBaLogoCommand 判断消息是否为 balogo 命令。
+func isBaLogoCommand(ctx *conduit.MessageContext) bool {
+	return strings.HasPrefix(strings.TrimSpace(ctx.RawMsg), "/balogo")
+}
+
+// ============================================================
+// Pass 实现
+// ============================================================
+
+// balogoResult BA-LOGO 生成结果，Pass 间通过 MessageContext 传递
+type balogoResult struct {
+	ImageURL string // 生成的 BA-LOGO 图片 URL
+}
+
+const balogoResultKey = "plugin.balogo.result" // MessageContext 中结果的键
+
+// balogoExecutePass 解析命令参数，生成 BA-LOGO 图片 URL
+type balogoExecutePass struct{}
+
+func (pass *balogoExecutePass) Execute(ctx *conduit.MessageContext) error {
+	// 解析命令：/balogo 左文字 右文字
+	raw := strings.TrimSpace(ctx.RawMsg)
+	raw = strings.TrimPrefix(raw, "/balogo")
+	raw = strings.TrimSpace(raw)
+
+	parts := strings.Fields(raw)
+
+	// 参数校验：必须恰好 2 部分
+	if len(parts) != 2 {
+		conduit.Set(ctx, balogoResultKey, &balogoResult{ImageURL: ""})
+		return nil
+	}
+
+	// 生成图片 URL（QueryEscape 编码中文等特殊字符，保证 URL 合法）
+	imageURL := fmt.Sprintf(baLogoURL, url.QueryEscape(parts[0]), url.QueryEscape(parts[1]))
+
+	conduit.Set(ctx, balogoResultKey, &balogoResult{ImageURL: imageURL})
+	return nil
+}
+
+// balogoReplyPass 组装 BA-LOGO 回复消息
+type balogoReplyPass struct{}
+
+func (pass *balogoReplyPass) Execute(ctx *conduit.MessageContext) error {
+	result, ok := conduit.Get[*balogoResult](ctx, balogoResultKey)
+	if !ok {
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "LOGO生成异常，请重试。",
+		})
+		return nil
+	}
+
+	// 参数不足时输出用法提示
+	if result.ImageURL == "" {
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "格式错误！用法：/balogo 左文字 右文字\n示例：/balogo 蔚蓝 档案",
+		})
+		return nil
+	}
+
+	// 输出图片 URL（由网关层识别为图片消息发送）
+	conduit.AppendOutput(ctx, &conduit.Message{
+		UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+		Content: result.ImageURL,
+	})
+	return nil
+}
+
+// ============================================================
+// AI 工具处理器
+// ============================================================
+
+// toolBaLogoGenerate 是 AI 工具处理器，生成 BA 风格 LOGO 图片 URL。
+func (p *BaLogoPlugin) toolBaLogoGenerate(_ context.Context, argsJSON string) (string, error) {
+	var args struct {
+		LeftText  string `json:"left_text"`
+		RightText string `json:"right_text"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return "", fmt.Errorf("参数解析失败: %w", err)
+	}
+
+	if args.LeftText == "" || args.RightText == "" {
+		return "", fmt.Errorf("左文字和右文字都不能为空")
+	}
+
+	return fmt.Sprintf(baLogoURL, url.QueryEscape(args.LeftText), url.QueryEscape(args.RightText)), nil
+}

--- a/internal/bizplugin/cat.go
+++ b/internal/bizplugin/cat.go
@@ -1,0 +1,183 @@
+package bizplugin
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"strconv"
+	"strings"
+
+	pluginpkg "github.com/DaWesen/lanmei-dream/internal/plugin"
+	"github.com/zrurf/conduit"
+)
+
+// ============================================================
+// CatPlugin 猫猫插件
+// ============================================================
+
+// CatPlugin 返回 HTTP Cat 图片。
+//
+// 功能：
+//   - /猫猫 或 /哈基米：返回随机 HTTP Cat 图片
+//   - /猫猫 404：返回指定状态码的猫猫图片
+//   - 无效状态码返回 404 猫猫图片
+//
+// 行为树：
+//
+//	subtree.cat → Sequence(isCatCommand, Action("pipeline.plugin.cat"))
+//
+// 管线：
+//
+//	pipeline.plugin.cat → [catPass]
+type CatPlugin struct{}
+
+// NewCatPlugin 创建猫猫插件。
+func NewCatPlugin() *CatPlugin {
+	return &CatPlugin{}
+}
+
+// Info 返回猫猫插件元信息。
+func (p *CatPlugin) Info() pluginpkg.PluginInfo {
+	return pluginpkg.PluginInfo{
+		ID:          "cat",
+		Name:        "猫猫",
+		Description: "随机猫猫图片",
+		Version:     "1.0.0",
+		Commands: []pluginpkg.CommandDef{
+			{Name: "猫猫", Description: "随机猫猫图片"},
+			{Name: "哈基米", Description: "随机猫猫图片"},
+		},
+		SubtreeID: pluginpkg.SubtreeID("cat"),
+		Tools: []pluginpkg.ToolDef{
+			{
+				Name:        "cat_image",
+				Description: "获取随机猫猫图片",
+				Handler:     p.toolCatImage,
+			},
+		},
+	}
+}
+
+// OnInit 初始化猫猫插件，注册 Pass、Pipeline 和 Subtree。
+func (p *CatPlugin) OnInit(ctx *pluginpkg.PluginContext) error {
+	// 注册 Pass
+	passID := pluginpkg.PassID("cat", "main")
+	pass := &catPass{}
+
+	if err := ctx.Engine.RegisterPass(passID, pass); err != nil {
+		return fmt.Errorf("register cat pass: %w", err)
+	}
+	ctx.Registry.TrackPass("cat", passID)
+
+	// 注册管线
+	pipelineID := pluginpkg.PipelineID("cat", "main")
+	pl := conduit.NewPipelineFromIDs(pipelineID, passID)
+	if err := ctx.Engine.RegisterPipeline(pl); err != nil {
+		return fmt.Errorf("register cat pipeline: %w", err)
+	}
+	ctx.Registry.TrackPipeline("cat", pipelineID)
+
+	// 注册行为树子树
+	subtree := conduit.NewSequence(
+		conduit.NewCondition(isCatCommand),
+		conduit.NewAction(pipelineID),
+	)
+	if err := ctx.Engine.RegisterSubtree(pluginpkg.SubtreeID("cat"), subtree); err != nil {
+		return fmt.Errorf("register cat subtree: %w", err)
+	}
+
+	return nil
+}
+
+// OnStart 猫猫插件无需后台任务。
+func (p *CatPlugin) OnStart(_ *pluginpkg.PluginContext) error { return nil }
+
+// OnStop 猫猫插件无需清理资源。
+func (p *CatPlugin) OnStop(_ *pluginpkg.PluginContext) error { return nil }
+
+// ============================================================
+// 条件判断
+// ============================================================
+
+// isCatCommand 判断消息是否为猫猫命令。
+// 匹配 /猫猫、/哈基米（无参数）或 /猫猫 <数字>、/哈基米 <数字>。
+func isCatCommand(ctx *conduit.MessageContext) bool {
+	msg := strings.TrimSpace(ctx.RawMsg)
+	if !strings.HasPrefix(msg, "/") {
+		return false
+	}
+	parts := strings.SplitN(msg, " ", 2)
+	cmd := parts[0]
+	return cmd == "/猫猫" || cmd == "/哈基米"
+}
+
+// ============================================================
+// Pass 实现
+// ============================================================
+
+// httpCatStatusCodes 是 HTTP Cat 支持的状态码列表（与上游 LanMei 保持一致）。
+// 来源：https://http.cat
+var httpCatStatusCodes = []int{
+	100, 101, 102, 103,
+	200, 201, 202, 203, 204, 205, 206, 207, 208, 214, 226,
+	300, 301, 302, 303, 304, 305, 307, 308,
+	400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 428, 429, 431, 444, 450, 451, 495, 496, 497, 498, 499,
+	500, 501, 502, 503, 504, 506, 507, 508, 509, 510, 511, 521, 522, 523, 525, 530, 599,
+}
+
+// httpCatURL 返回指定状态码的 HTTP Cat 图片 URL。
+func httpCatURL(code int) string {
+	return fmt.Sprintf("https://http.cat/%d.jpg", code)
+}
+
+// isValidCatCode 检查状态码是否在 HTTP Cat 列表中。
+func isValidCatCode(code int) bool {
+	for _, c := range httpCatStatusCodes {
+		if c == code {
+			return true
+		}
+	}
+	return false
+}
+
+// catPass 解析命令参数并输出猫猫图片 URL。
+type catPass struct{}
+
+func (pass *catPass) Execute(ctx *conduit.MessageContext) error {
+	msg := strings.TrimSpace(ctx.RawMsg)
+	parts := strings.SplitN(msg, " ", 2)
+
+	var imageURL string
+
+	if len(parts) == 2 && strings.TrimSpace(parts[1]) != "" {
+		// 带参数：尝试解析为状态码
+		arg := strings.TrimSpace(parts[1])
+		code, err := strconv.Atoi(arg)
+		if err != nil || !isValidCatCode(code) {
+			// 无效状态码，返回 404
+			imageURL = httpCatURL(404)
+		} else {
+			imageURL = httpCatURL(code)
+		}
+	} else {
+		// 无参数：随机返回一张
+		code := httpCatStatusCodes[rand.IntN(len(httpCatStatusCodes))]
+		imageURL = httpCatURL(code)
+	}
+
+	conduit.AppendOutput(ctx, &conduit.Message{
+		UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+		Content: imageURL,
+	})
+	return nil
+}
+
+// ============================================================
+// AI 工具
+// ============================================================
+
+// toolCatImage 是 AI 工具处理器，返回随机猫猫图片 URL。
+func (p *CatPlugin) toolCatImage(_ context.Context, _ string) (string, error) {
+	code := httpCatStatusCodes[rand.IntN(len(httpCatStatusCodes))]
+	return httpCatURL(code), nil
+}

--- a/internal/bizplugin/github_card.go
+++ b/internal/bizplugin/github_card.go
@@ -1,0 +1,146 @@
+package bizplugin
+
+import (
+	"crypto/rand"
+	"fmt"
+	"regexp"
+
+	pluginpkg "github.com/DaWesen/lanmei-dream/internal/plugin"
+	"github.com/zrurf/conduit"
+)
+
+// ============================================================
+// GitHubCardPlugin GitHub卡片插件
+// ============================================================
+
+// GitHubCardPlugin 检测消息中的 GitHub 仓库链接，自动返回 OpenGraph 预览卡片。
+//
+// 功能：
+//   - 自动触发：消息中包含 GitHub 仓库 URL 时自动响应
+//   - 返回 OpenGraph 预览卡片图片
+//
+// 行为树：
+//
+//	subtree.github_card → Sequence(hasGitHubURL, Action("pipeline.plugin.github_card"))
+//
+// 管线：
+//
+//	pipeline.plugin.github_card → [githubCardPass]
+type GitHubCardPlugin struct{}
+
+// NewGitHubCardPlugin 创建 GitHub 卡片插件。
+func NewGitHubCardPlugin() *GitHubCardPlugin {
+	return &GitHubCardPlugin{}
+}
+
+// Info 返回 GitHub 卡片插件元信息。
+func (p *GitHubCardPlugin) Info() pluginpkg.PluginInfo {
+	return pluginpkg.PluginInfo{
+		ID:          "github_card",
+		Name:        "GitHub卡片",
+		Description: "检测到GitHub链接自动返回卡片预览",
+		Version:     "1.0.0",
+		Commands:    nil, // 无斜杠命令，自动触发
+		SubtreeID:   pluginpkg.SubtreeID("github_card"),
+		Tools:       nil, // 无 AI 工具
+	}
+}
+
+// OnInit 初始化 GitHub 卡片插件，注册 Pass、Pipeline 和 Subtree。
+func (p *GitHubCardPlugin) OnInit(ctx *pluginpkg.PluginContext) error {
+	// 注册 Pass
+	passID := pluginpkg.PassID("github_card", "main")
+	pass := &githubCardPass{}
+
+	if err := ctx.Engine.RegisterPass(passID, pass); err != nil {
+		return fmt.Errorf("register github_card pass: %w", err)
+	}
+	ctx.Registry.TrackPass("github_card", passID)
+
+	// 注册管线
+	pipelineID := pluginpkg.PipelineID("github_card", "main")
+	pl := conduit.NewPipelineFromIDs(pipelineID, passID)
+	if err := ctx.Engine.RegisterPipeline(pl); err != nil {
+		return fmt.Errorf("register github_card pipeline: %w", err)
+	}
+	ctx.Registry.TrackPipeline("github_card", pipelineID)
+
+	// 注册行为树子树：GitHub URL 正则匹配路由
+	subtree := conduit.NewSequence(
+		conduit.NewCondition(hasGitHubURL),
+		conduit.NewAction(pipelineID),
+	)
+	if err := ctx.Engine.RegisterSubtree(pluginpkg.SubtreeID("github_card"), subtree); err != nil {
+		return fmt.Errorf("register github_card subtree: %w", err)
+	}
+
+	return nil
+}
+
+// OnStart GitHub 卡片插件无需后台任务。
+func (p *GitHubCardPlugin) OnStart(_ *pluginpkg.PluginContext) error { return nil }
+
+// OnStop GitHub 卡片插件无需清理资源。
+func (p *GitHubCardPlugin) OnStop(_ *pluginpkg.PluginContext) error { return nil }
+
+// ============================================================
+// 条件判断
+// ============================================================
+
+// githubURLRe 匹配 GitHub 仓库 URL。
+// 示例：github.com/user/repo、www.github.com/org/project/issues/1
+var githubURLRe = regexp.MustCompile(
+	`(?i)(?:https?://)?(?:www\.)?github\.com/([a-z0-9_.-]+/[a-z0-9_.-]+(?:/[^\s?#]*)?)`,
+)
+
+// hasGitHubURL 判断消息是否包含 GitHub 仓库 URL。
+func hasGitHubURL(ctx *conduit.MessageContext) bool {
+	return githubURLRe.MatchString(ctx.RawMsg)
+}
+
+// ============================================================
+// Pass 实现
+// ============================================================
+
+// githubCardExtractKey 是 MessageContext 中提取到的 GitHub 路径的键。
+const githubCardExtractKey = "plugin.github_card.path"
+
+// githubCardPass 从消息中提取 GitHub 仓库 URL，构建 OpenGraph 卡片链接并输出。
+type githubCardPass struct{}
+
+func (pass *githubCardPass) Execute(ctx *conduit.MessageContext) error {
+	match := githubURLRe.FindStringSubmatch(ctx.RawMsg)
+	if len(match) < 2 {
+		// 正则未匹配（理论上不会发生，条件函数已过滤），静默返回
+		return nil
+	}
+
+	path := match[1]
+
+	// 生成随机字符串用于 OpenGraph URL 的缓存键
+	randStr, err := randomHex(8)
+	if err != nil {
+		randStr = "0" // 降级处理
+	}
+
+	imageURL := fmt.Sprintf("https://opengraph.githubassets.com/%s/%s", randStr, path)
+
+	conduit.AppendOutput(ctx, &conduit.Message{
+		UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+		Content: imageURL,
+	})
+	return nil
+}
+
+// ============================================================
+// 辅助函数
+// ============================================================
+
+// randomHex 生成 n 字节的随机十六进制字符串。
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", b), nil
+}

--- a/internal/bizplugin/music.go
+++ b/internal/bizplugin/music.go
@@ -1,0 +1,494 @@
+package bizplugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	pluginpkg "github.com/DaWesen/lanmei-dream/internal/plugin"
+	"github.com/zrurf/conduit"
+	"go.uber.org/zap"
+)
+
+// ============================================================
+// MusicPlugin 网易云点歌插件
+// ============================================================
+
+// MusicPlugin 实现网易云音乐搜索与点歌功能。
+//
+// 功能：
+//   - /music 歌曲名 → 搜索网易云音乐，展示前 3 首结果
+//   - 用户回复序号（1/2/3）→ 播放所选歌曲
+//   - 会话 60 秒后自动过期
+//   - 会话按群+用户隔离
+//
+// 行为树：
+//
+//	subtree.music → Selector [
+//	  Sequence(isMusicCommand, Action(pipeline.music.search))
+//	  Sequence(isMusicSelect, Action(pipeline.music.select))
+//	]
+//
+// 管线：
+//
+//	pipeline.music.search  → [musicSearchPass]
+//	pipeline.music.select  → [musicSelectPass]
+type MusicPlugin struct {
+	ncmURL string // 网易云音乐 API 基础 URL
+	store  conduit.StateStore
+	logger *zap.Logger
+}
+
+// NewMusicPlugin 创建网易云点歌插件。
+// ncmURL 为网易云音乐 API 基础 URL（如 http://ncm-api:3000），为空时插件仍可初始化但使用时报错。
+func NewMusicPlugin(ncmURL string, logger *zap.Logger) *MusicPlugin {
+	return &MusicPlugin{ncmURL: ncmURL, logger: logger}
+}
+
+// Info 返回网易云点歌插件元信息。
+func (p *MusicPlugin) Info() pluginpkg.PluginInfo {
+	return pluginpkg.PluginInfo{
+		ID:          "music",
+		Name:        "网易云点歌",
+		Description: "搜索网易云音乐并点歌",
+		Version:     "1.0.0",
+		Commands: []pluginpkg.CommandDef{
+			{Name: "music", Description: "搜索网易云音乐，格式：/music 歌曲名"},
+		},
+		SubtreeID: pluginpkg.SubtreeID("music"),
+		Tools: []pluginpkg.ToolDef{
+			{
+				Name:        "music_search",
+				Description: "搜索网易云音乐，返回匹配的歌曲列表",
+				Handler:     p.toolMusicSearch,
+			},
+		},
+	}
+}
+
+// OnInit 初始化网易云点歌插件，注册 Pass、Pipeline 和 Subtree。
+func (p *MusicPlugin) OnInit(ctx *pluginpkg.PluginContext) error {
+	p.store = ctx.Store
+
+	// ── 注册 Pass ──
+
+	searchPassID := pluginpkg.PassID("music", "search")
+	searchPass := &musicSearchPass{ncmURL: p.ncmURL, store: p.store, logger: p.logger}
+
+	if err := ctx.Engine.RegisterPass(searchPassID, searchPass); err != nil {
+		return fmt.Errorf("register music search pass: %w", err)
+	}
+	ctx.Registry.TrackPass("music", searchPassID)
+
+	selectPassID := pluginpkg.PassID("music", "select")
+	selectPass := &musicSelectPass{store: p.store, logger: p.logger}
+
+	if err := ctx.Engine.RegisterPass(selectPassID, selectPass); err != nil {
+		return fmt.Errorf("register music select pass: %w", err)
+	}
+	ctx.Registry.TrackPass("music", selectPassID)
+
+	// ── 注册管线 ──
+
+	searchPipelineID := pluginpkg.PipelineID("music", "search")
+	searchPl := conduit.NewPipelineFromIDs(searchPipelineID, searchPassID)
+	if err := ctx.Engine.RegisterPipeline(searchPl); err != nil {
+		return fmt.Errorf("register music search pipeline: %w", err)
+	}
+	ctx.Registry.TrackPipeline("music", searchPipelineID)
+
+	selectPipelineID := pluginpkg.PipelineID("music", "select")
+	selectPl := conduit.NewPipelineFromIDs(selectPipelineID, selectPassID)
+	if err := ctx.Engine.RegisterPipeline(selectPl); err != nil {
+		return fmt.Errorf("register music select pipeline: %w", err)
+	}
+	ctx.Registry.TrackPipeline("music", selectPipelineID)
+
+	// ── 注册行为树子树 ──
+	// 搜索命令优先匹配；若不匹配则检查是否为序号选择（需有活跃会话）
+	subtree := conduit.NewSelector(
+		conduit.NewSequence(
+			conduit.NewCondition(isMusicCommand),
+			conduit.NewAction(searchPipelineID),
+		),
+		conduit.NewSequence(
+			conduit.NewCondition(isMusicSelect(p.store)),
+			conduit.NewAction(selectPipelineID),
+		),
+	)
+	if err := ctx.Engine.RegisterSubtree(pluginpkg.SubtreeID("music"), subtree); err != nil {
+		return fmt.Errorf("register music subtree: %w", err)
+	}
+
+	return nil
+}
+
+// OnStart 网易云点歌插件无需后台任务。
+func (p *MusicPlugin) OnStart(_ *pluginpkg.PluginContext) error { return nil }
+
+// OnStop 网易云点歌插件无需清理资源。
+func (p *MusicPlugin) OnStop(_ *pluginpkg.PluginContext) error { return nil }
+
+// ============================================================
+// 条件判断
+// ============================================================
+
+// isMusicCommand 判断消息是否为 /music 命令。
+func isMusicCommand(ctx *conduit.MessageContext) bool {
+	msg := strings.TrimSpace(ctx.RawMsg)
+	return strings.HasPrefix(msg, "/music ") && len(strings.TrimSpace(strings.TrimPrefix(msg, "/music"))) > 0
+}
+
+// isMusicSelect 返回一个条件函数，判断消息是否为点歌序号选择（1/2/3）且存在活跃会话。
+// 使用闭包捕获 StateStore 以检查会话。
+func isMusicSelect(store conduit.StateStore) func(*conduit.MessageContext) bool {
+	return func(ctx *conduit.MessageContext) bool {
+		msg := strings.TrimSpace(ctx.RawMsg)
+		if msg != "1" && msg != "2" && msg != "3" {
+			return false
+		}
+		// 检查是否存在活跃会话
+		sessionKey := musicSessionKey(ctx.GroupID, ctx.UserID)
+		data, err := store.Get(ctx.Ctx, sessionKey)
+		if err != nil || data == "" {
+			return false
+		}
+		return true
+	}
+}
+
+// ============================================================
+// 会话数据结构
+// ============================================================
+
+// musicSession 点歌会话数据，存储在 StateStore 中。
+type musicSession struct {
+	Songs []musicSong `json:"songs"`
+}
+
+// musicSong 单首歌曲信息。
+type musicSong struct {
+	ID         int64  `json:"id"`
+	Name       string `json:"name"`
+	Artists    string `json:"artists"` // 逗号分隔的歌手名
+	Album      string `json:"album"`
+	DurationMs int64  `json:"duration_ms"`
+}
+
+// musicSessionTTL 会话过期时间。
+const musicSessionTTL = 60 * time.Second
+
+// musicSessionKey 生成会话的 StateStore 键，按群+用户隔离。
+func musicSessionKey(groupID, userID string) string {
+	return pluginpkg.StoreKey("music", "session:"+groupID+":"+userID)
+}
+
+// ============================================================
+// 网易云音乐 API 响应结构
+// ============================================================
+
+// ncmSearchResponse 网易云音乐搜索 API 响应。
+type ncmSearchResponse struct {
+	Result ncmSearchResult `json:"result"`
+}
+
+// ncmSearchResult 搜索结果。
+type ncmSearchResult struct {
+	Songs []ncmSong `json:"songs"`
+}
+
+// ncmSong 单首歌曲 API 数据。
+type ncmSong struct {
+	ID         int64       `json:"id"`
+	Name       string      `json:"name"`
+	Artists    []ncmArtist `json:"artists"`
+	Album      ncmAlbum    `json:"album"`
+	DurationMs int64       `json:"duration"`
+}
+
+// ncmArtist 歌手。
+type ncmArtist struct {
+	Name string `json:"name"`
+}
+
+// ncmAlbum 专辑。
+type ncmAlbum struct {
+	Name string `json:"name"`
+}
+
+// ============================================================
+// NCM API 搜索
+// ============================================================
+
+// searchNCM 调用网易云音乐搜索 API，返回前 limit 首结果。
+func searchNCM(ctx context.Context, ncmURL, keyword string, limit int) ([]ncmSong, error) {
+	url := fmt.Sprintf("%s/search?keywords=%s&limit=%d", ncmURL, keyword, limit)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("api returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var result ncmSearchResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return result.Result.Songs, nil
+}
+
+// ============================================================
+// 辅助函数
+// ============================================================
+
+// formatDuration 将毫秒时长格式化为 m:ss。
+func formatDuration(ms int64) string {
+	totalSec := ms / 1000
+	min := totalSec / 60
+	sec := totalSec % 60
+	return fmt.Sprintf("%d:%02d", min, sec)
+}
+
+// ncmSongToMusicSong 将 API 歌曲数据转换为会话存储格式。
+func ncmSongToMusicSong(s ncmSong) musicSong {
+	artistNames := make([]string, 0, len(s.Artists))
+	for _, a := range s.Artists {
+		if a.Name != "" {
+			artistNames = append(artistNames, a.Name)
+		}
+	}
+	return musicSong{
+		ID:         s.ID,
+		Name:       s.Name,
+		Artists:    strings.Join(artistNames, ","),
+		Album:      s.Album.Name,
+		DurationMs: s.DurationMs,
+	}
+}
+
+// ============================================================
+// Pass 实现：搜索
+// ============================================================
+
+// musicSearchPass 搜索网易云音乐，存储结果并输出列表。
+type musicSearchPass struct {
+	ncmURL string
+	store  conduit.StateStore
+	logger *zap.Logger
+}
+
+func (pass *musicSearchPass) Execute(ctx *conduit.MessageContext) error {
+	// 解析歌曲名
+	keyword := strings.TrimSpace(strings.TrimPrefix(ctx.RawMsg, "/music"))
+	keyword = strings.TrimSpace(keyword)
+	if keyword == "" {
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "请输入歌曲名，格式：/music 歌曲名",
+		})
+		return nil
+	}
+
+	// 检查 API 是否配置
+	if pass.ncmURL == "" {
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "音乐服务未配置",
+		})
+		return nil
+	}
+
+	// 调用搜索 API
+	songs, err := searchNCM(ctx.Ctx, pass.ncmURL, keyword, 3)
+	if err != nil {
+		pass.logger.Error("music: search failed", zap.String("keyword", keyword), zap.Error(err))
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "搜索失败，请稍后重试",
+		})
+		return nil
+	}
+
+	if len(songs) == 0 {
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: fmt.Sprintf("未找到「%s」的相关歌曲", keyword),
+		})
+		return nil
+	}
+
+	// 转换为会话格式并存储
+	musicSongs := make([]musicSong, 0, len(songs))
+	for _, s := range songs {
+		musicSongs = append(musicSongs, ncmSongToMusicSong(s))
+	}
+
+	session := musicSession{Songs: musicSongs}
+	sessionJSON, err := json.Marshal(session)
+	if err != nil {
+		pass.logger.Error("music: marshal session failed", zap.Error(err))
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "搜索结果处理失败",
+		})
+		return nil
+	}
+
+	sessionKey := musicSessionKey(ctx.GroupID, ctx.UserID)
+	if err := pass.store.Set(ctx.Ctx, sessionKey, string(sessionJSON), musicSessionTTL); err != nil {
+		pass.logger.Error("music: save session failed", zap.Error(err))
+	}
+
+	// 格式化输出列表
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("找到 %d 首歌曲，请回复序号选择：\n", len(musicSongs)))
+	for i, s := range musicSongs {
+		sb.WriteString(fmt.Sprintf("%d. %s - %s 《%s》 [%s]\n",
+			i+1, s.Name, s.Artists, s.Album, formatDuration(s.DurationMs)))
+	}
+
+	conduit.AppendOutput(ctx, &conduit.Message{
+		UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+		Content: sb.String(),
+	})
+	return nil
+}
+
+// ============================================================
+// Pass 实现：选择
+// ============================================================
+
+// musicSelectPass 根据用户输入的序号选择歌曲并输出详情。
+type musicSelectPass struct {
+	store  conduit.StateStore
+	logger *zap.Logger
+}
+
+func (pass *musicSelectPass) Execute(ctx *conduit.MessageContext) error {
+	// 解析序号
+	selection, err := strconv.Atoi(strings.TrimSpace(ctx.RawMsg))
+	if err != nil || selection < 1 || selection > 3 {
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "请回复 1、2 或 3 选择歌曲",
+		})
+		return nil
+	}
+
+	// 读取会话
+	sessionKey := musicSessionKey(ctx.GroupID, ctx.UserID)
+	data, err := pass.store.Get(ctx.Ctx, sessionKey)
+	if err != nil || data == "" {
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "点歌会话已过期，请重新搜索",
+		})
+		return nil
+	}
+
+	var session musicSession
+	if err := json.Unmarshal([]byte(data), &session); err != nil {
+		pass.logger.Error("music: unmarshal session failed", zap.Error(err))
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "会话数据异常，请重新搜索",
+		})
+		return nil
+	}
+
+	if selection > len(session.Songs) {
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: fmt.Sprintf("序号 %d 超出范围，请选择 1~%d", selection, len(session.Songs)),
+		})
+		return nil
+	}
+
+	song := session.Songs[selection-1]
+
+	// 输出选中歌曲
+	content := fmt.Sprintf("🎵 %s - %s 《%s》\n网易云音乐: https://music.163.com/#/song?id=%d",
+		song.Name, song.Artists, song.Album, song.ID)
+
+	conduit.AppendOutput(ctx, &conduit.Message{
+		UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+		Content: content,
+	})
+
+	// 选择后删除会话
+	_ = pass.store.Delete(ctx.Ctx, sessionKey)
+
+	return nil
+}
+
+// ============================================================
+// AI 工具处理器
+// ============================================================
+
+// toolMusicSearch 是 AI 工具处理器，搜索网易云音乐。
+func (p *MusicPlugin) toolMusicSearch(ctx context.Context, argsJSON string) (string, error) {
+	var args struct {
+		Keyword string `json:"keyword"`
+		Limit   int    `json:"limit"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return "", fmt.Errorf("参数解析失败: %w", err)
+	}
+
+	if args.Keyword == "" {
+		return "", fmt.Errorf("关键词不能为空")
+	}
+	if p.ncmURL == "" {
+		return "", fmt.Errorf("音乐服务未配置")
+	}
+
+	limit := args.Limit
+	if limit <= 0 || limit > 10 {
+		limit = 3
+	}
+
+	songs, err := searchNCM(ctx, p.ncmURL, args.Keyword, limit)
+	if err != nil {
+		return "", fmt.Errorf("搜索失败: %w", err)
+	}
+
+	if len(songs) == 0 {
+		return fmt.Sprintf("未找到「%s」的相关歌曲", args.Keyword), nil
+	}
+
+	var parts []string
+	for i, s := range songs {
+		artistNames := make([]string, 0, len(s.Artists))
+		for _, a := range s.Artists {
+			if a.Name != "" {
+				artistNames = append(artistNames, a.Name)
+			}
+		}
+		artists := strings.Join(artistNames, ",")
+		parts = append(parts, fmt.Sprintf("%d. %s - %s 《%s》 [%s] (id:%d)",
+			i+1, s.Name, artists, s.Album.Name, formatDuration(s.DurationMs), s.ID))
+	}
+
+	return strings.Join(parts, "\n"), nil
+}

--- a/internal/bizplugin/ping.go
+++ b/internal/bizplugin/ping.go
@@ -1,0 +1,134 @@
+package bizplugin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	pluginpkg "github.com/DaWesen/lanmei-dream/internal/plugin"
+	"github.com/zrurf/conduit"
+)
+
+// ============================================================
+// PingPlugin Ping插件
+// ============================================================
+
+// PingPlugin 实现最简单的 Ping/Pong 响应功能。
+//
+// 功能：
+//   - 用户发送 /ping，机器人回复 Pong!
+//   - 通过 Conduit 行为树子树实现消息路由
+//
+// 行为树：
+//
+//	subtree.ping → Sequence(isPingCommand, Action("pipeline.ping.main"))
+//
+// 管线：
+//
+//	pipeline.ping.main → [pingReplyPass]
+type PingPlugin struct{}
+
+// NewPingPlugin 创建 Ping 插件。
+func NewPingPlugin() *PingPlugin {
+	return &PingPlugin{}
+}
+
+// Info 返回 Ping 插件元信息。
+func (p *PingPlugin) Info() pluginpkg.PluginInfo {
+	return pluginpkg.PluginInfo{
+		ID:          "ping",
+		Name:        "Ping",
+		Description: "响应Ping命令",
+		Version:     "1.0.0",
+		Commands: []pluginpkg.CommandDef{
+			{Name: "ping", Description: "测试机器人是否在线"},
+		},
+		SubtreeID: pluginpkg.SubtreeID("ping"),
+		Tools: []pluginpkg.ToolDef{
+			{
+				Name:        "ping",
+				Description: "测试机器人是否在线，返回Pong",
+				Handler:     p.toolPing,
+			},
+		},
+	}
+}
+
+// OnInit 初始化 Ping 插件，注册 Pass、Pipeline 和 Subtree。
+func (p *PingPlugin) OnInit(ctx *pluginpkg.PluginContext) error {
+	// 注册 Pass
+	replyPassID := pluginpkg.PassID("ping", "reply")
+	replyPass := &pingReplyPass{}
+
+	if err := ctx.Engine.RegisterPass(replyPassID, replyPass); err != nil {
+		return fmt.Errorf("register reply pass: %w", err)
+	}
+
+	// 跟踪 Pass，卸载时自动清理
+	ctx.Registry.TrackPass("ping", replyPassID)
+
+	// 注册管线
+	pipelineID := pluginpkg.PipelineID("ping", "main")
+	pl := conduit.NewPipelineFromIDs(
+		pipelineID,
+		replyPassID,
+	)
+	if err := ctx.Engine.RegisterPipeline(pl); err != nil {
+		return fmt.Errorf("register pipeline: %w", err)
+	}
+
+	// 跟踪 Pipeline，卸载时自动清理
+	ctx.Registry.TrackPipeline("ping", pipelineID)
+
+	// 注册行为树子树：Ping 命令路由
+	subtree := conduit.NewSequence(
+		conduit.NewCondition(isPingCommand),
+		conduit.NewAction(pipelineID),
+	)
+	if err := ctx.Engine.RegisterSubtree(pluginpkg.SubtreeID("ping"), subtree); err != nil {
+		return fmt.Errorf("register subtree: %w", err)
+	}
+
+	return nil
+}
+
+// OnStart Ping 插件无需后台任务。
+func (p *PingPlugin) OnStart(_ *pluginpkg.PluginContext) error { return nil }
+
+// OnStop Ping 插件无需清理资源。
+func (p *PingPlugin) OnStop(_ *pluginpkg.PluginContext) error { return nil }
+
+// ============================================================
+// 条件判断
+// ============================================================
+
+// isPingCommand 判断消息是否为 Ping 命令。
+func isPingCommand(ctx *conduit.MessageContext) bool {
+	return strings.TrimSpace(ctx.RawMsg) == "/ping"
+}
+
+// ============================================================
+// Pass 实现
+// ============================================================
+
+// pingReplyPass 组装 Pong 回复消息
+type pingReplyPass struct{}
+
+func (pass *pingReplyPass) Execute(ctx *conduit.MessageContext) error {
+	conduit.AppendOutput(ctx, &conduit.Message{
+		UserID:  ctx.UserID,
+		GroupID: ctx.GroupID,
+		IsGroup: ctx.IsGroup,
+		Content: "Pong!",
+	})
+	return nil
+}
+
+// ============================================================
+// AI 工具处理器
+// ============================================================
+
+// toolPing 是 AI 工具处理器，返回 Pong。
+func (p *PingPlugin) toolPing(_ context.Context, _ string) (string, error) {
+	return "Pong!", nil
+}

--- a/internal/bizplugin/registry.go
+++ b/internal/bizplugin/registry.go
@@ -25,6 +25,7 @@ type BusinessRegistry struct {
 	cfg      *config.PluginBuiltinsConfig // 内置插件开关配置
 	registry *pluginpkg.Registry          // 插件注册表
 	db       *database.DB                 // 数据库（签到等插件依赖）
+	ncmURL   string                       // 网易云音乐 API 地址（点歌插件使用）
 	logger   *zap.Logger
 }
 
@@ -36,6 +37,11 @@ func NewBusinessRegistry(cfg *config.PluginBuiltinsConfig, registry *pluginpkg.R
 		db:       db,
 		logger:   logger,
 	}
+}
+
+// SetNCMURL 设置网易云音乐 API 地址（点歌插件依赖）。
+func (r *BusinessRegistry) SetNCMURL(url string) {
+	r.ncmURL = url
 }
 
 // RegisterBuiltins 按配置注册所有内置业务插件。
@@ -55,28 +61,66 @@ func (r *BusinessRegistry) RegisterBuiltins() error {
 		logger = zap.NewNop()
 	}
 
-	// ── 签到插件 ──
-	enabled := r.cfg == nil || r.cfg.Signin // 配置为空时按默认开启处理
-	if !enabled {
-		logger.Info("bizplugin: 签到插件已由配置关闭，跳过注册")
-	} else if _, loaded := r.registry.Get("signin"); loaded {
-		logger.Info("bizplugin: 签到插件已由 Wasm 动态加载，跳过内置注册")
-	} else {
-		if err := r.registry.Register(NewSigninPlugin(r.db, logger)); err != nil {
-			return fmt.Errorf("bizplugin: 注册签到插件失败: %w", err)
+	// builtins 开关（配置为空时按默认开启处理）
+	builtins := r.cfg
+	if builtins == nil {
+		builtins = &config.PluginBuiltinsConfig{}
+	}
+
+	// 注册一个内置插件（启用开关 + Wasm 去重 + 注册）
+	register := func(sw bool, pluginID string, plugin pluginpkg.Plugin) error {
+		if !sw {
+			logger.Info("bizplugin: 插件已由配置关闭，跳过注册", zap.String("plugin", pluginID))
+			return nil
 		}
+		if _, loaded := r.registry.Get(pluginID); loaded {
+			logger.Info("bizplugin: 插件已由 Wasm 动态加载，跳过内置注册", zap.String("plugin", pluginID))
+			return nil
+		}
+		if err := r.registry.Register(plugin); err != nil {
+			return fmt.Errorf("bizplugin: 注册 %s 插件失败: %w", pluginID, err)
+		}
+		return nil
+	}
+
+	// ── 签到插件 ──
+	if err := register(builtins.Signin, "signin", NewSigninPlugin(r.db, logger)); err != nil {
+		return err
 	}
 
 	// ── 入群欢迎插件 ──
-	enabled = r.cfg == nil || r.cfg.Welcome
-	if !enabled {
-		logger.Info("bizplugin: 入群欢迎插件已由配置关闭，跳过注册")
-	} else if _, loaded := r.registry.Get("welcome"); loaded {
-		logger.Info("bizplugin: 入群欢迎插件已由 Wasm 动态加载，跳过内置注册")
-	} else {
-		if err := r.registry.Register(NewWelcomePlugin(logger)); err != nil {
-			return fmt.Errorf("bizplugin: 注册入群欢迎插件失败: %w", err)
-		}
+	if err := register(builtins.Welcome, "welcome", NewWelcomePlugin(logger)); err != nil {
+		return err
+	}
+
+	// ── 签到积分排行榜插件 ──
+	if err := register(builtins.Rank, "signin_rank", NewRankPlugin(r.db, logger)); err != nil {
+		return err
+	}
+
+	// ── 猫猫图片插件 ──
+	if err := register(builtins.Cat, "cat", NewCatPlugin()); err != nil {
+		return err
+	}
+
+	// ── 蔚蓝档案 LOGO 插件 ──
+	if err := register(builtins.BaLogo, "balogo", NewBaLogoPlugin()); err != nil {
+		return err
+	}
+
+	// ── Ping 连通性测试插件 ──
+	if err := register(builtins.Ping, "ping", NewPingPlugin()); err != nil {
+		return err
+	}
+
+	// ── GitHub 链接卡片插件 ──
+	if err := register(builtins.GitHubCard, "github_card", NewGitHubCardPlugin()); err != nil {
+		return err
+	}
+
+	// ── 网易云点歌插件 ──
+	if err := register(builtins.Music, "music", NewMusicPlugin(r.ncmURL, logger)); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/bizplugin/signin.go
+++ b/internal/bizplugin/signin.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand/v2"
+	"sort"
 	"strings"
 	"time"
 
@@ -17,20 +19,23 @@ import (
 // SigninPlugin 签到插件
 // ============================================================
 
-// SigninPlugin 实现每日签到功能。
+// SigninPlugin 实现每日签到和试试手气功能。
 //
-// 功能：
-//   - 用户每日签到，获取积分奖励
-//   - 连续签到天数累积，中断则重新计算
-//   - 通过 Conduit 行为树子树实现消息路由
+// 功能（与上游 LanMei 保持一致）：
+//   - /签到：用户每日签到，固定获得 5 积分，附带随机事件描述
+//   - /试试手气：随机签到，概率获得不同积分（可能为正也可能为负），附带随机事件描述
 //
 // 行为树：
 //
-//	subtree.signin → Sequence(IsSigninCommand, Action("pipeline.plugin.signin"))
+//	subtree.signin → Selector [
+//	  Sequence(isSigninCommand, Action(pipeline.signin.normal))
+//	  Sequence(isRandomSigninCommand, Action(pipeline.signin.random))
+//	]
 //
-// 管线（动态模式，支持运行时热替换）：
+// 管线：
 //
-//	pipeline.plugin.signin → [executePass, replyPass]
+//	pipeline.signin.normal  → [executePass, replyPass]
+//	pipeline.signin.random  → [executePass, replyPass]
 type SigninPlugin struct {
 	db     *database.DB
 	store  conduit.StateStore
@@ -47,10 +52,11 @@ func (p *SigninPlugin) Info() pluginpkg.PluginInfo {
 	return pluginpkg.PluginInfo{
 		ID:          "signin",
 		Name:        "签到",
-		Description: "每日试试手气",
-		Version:     "1.0.0",
+		Description: "每日签到和试试手气",
+		Version:     "2.0.0",
 		Commands: []pluginpkg.CommandDef{
-			{Name: "签到", Description: "每日试试手气"},
+			{Name: "签到", Description: "每日签到，获取积分奖励"},
+			{Name: "试试手气", Description: "试试手气，随机获取积分"},
 		},
 		SubtreeID: pluginpkg.SubtreeID("signin"),
 		Tools: []pluginpkg.ToolDef{
@@ -58,6 +64,11 @@ func (p *SigninPlugin) Info() pluginpkg.PluginInfo {
 				Name:        "signin_status",
 				Description: "查询用户签到状态和积分",
 				Handler:     p.toolSigninStatus,
+			},
+			{
+				Name:        "signin_random",
+				Description: "帮用户试试手气，进行随机签到",
+				Handler:     p.toolSigninRandom,
 			},
 		},
 	}
@@ -68,42 +79,72 @@ func (p *SigninPlugin) OnInit(ctx *pluginpkg.PluginContext) error {
 	p.db = ctx.DB
 	p.store = ctx.Store
 
-	// 注册 Pass（依赖直接注入 Pass 结构体）
-	executePassID := pluginpkg.PassID("signin", "execute")
-	replyPassID := pluginpkg.PassID("signin", "reply")
+	// ── 注册 Pass ──
 
-	executePass := &signinExecutePass{db: p.db, store: p.store, logger: p.logger}
-	replyPass := &signinReplyPass{}
+	// 普通签到
+	normalExecPassID := pluginpkg.PassID("signin", "normal_execute")
+	normalReplyPassID := pluginpkg.PassID("signin", "normal_reply")
+	normalExecPass := &signinNormalExecutePass{db: p.db, store: p.store, logger: p.logger}
+	normalReplyPass := &signinNormalReplyPass{}
 
-	if err := ctx.Engine.RegisterPass(executePassID, executePass); err != nil {
-		return fmt.Errorf("register execute pass: %w", err)
+	if err := ctx.Engine.RegisterPass(normalExecPassID, normalExecPass); err != nil {
+		return fmt.Errorf("register normal execute pass: %w", err)
 	}
-	if err := ctx.Engine.RegisterPass(replyPassID, replyPass); err != nil {
-		return fmt.Errorf("register reply pass: %w", err)
+	if err := ctx.Engine.RegisterPass(normalReplyPassID, normalReplyPass); err != nil {
+		return fmt.Errorf("register normal reply pass: %w", err)
 	}
+	ctx.Registry.TrackPass("signin", normalExecPassID)
+	ctx.Registry.TrackPass("signin", normalReplyPassID)
 
-	// 跟踪 Pass，卸载时自动清理
-	ctx.Registry.TrackPass("signin", executePassID)
-	ctx.Registry.TrackPass("signin", replyPassID)
+	// 随机签到
+	randomExecPassID := pluginpkg.PassID("signin", "random_execute")
+	randomReplyPassID := pluginpkg.PassID("signin", "random_reply")
+	randomExecPass := &signinRandomExecutePass{db: p.db, store: p.store, logger: p.logger}
+	randomReplyPass := &signinRandomReplyPass{}
 
-	// 注册动态管线（通过 Pass ID 引用，支持运行时热替换）
-	pipelineID := pluginpkg.PipelineID("signin", "main")
-	pl := conduit.NewPipelineFromIDs(
-		pipelineID,
-		executePassID,
-		replyPassID,
+	if err := ctx.Engine.RegisterPass(randomExecPassID, randomExecPass); err != nil {
+		return fmt.Errorf("register random execute pass: %w", err)
+	}
+	if err := ctx.Engine.RegisterPass(randomReplyPassID, randomReplyPass); err != nil {
+		return fmt.Errorf("register random reply pass: %w", err)
+	}
+	ctx.Registry.TrackPass("signin", randomExecPassID)
+	ctx.Registry.TrackPass("signin", randomReplyPassID)
+
+	// ── 注册管线 ──
+
+	normalPipelineID := pluginpkg.PipelineID("signin", "normal")
+	normalPl := conduit.NewPipelineFromIDs(
+		normalPipelineID,
+		normalExecPassID,
+		normalReplyPassID,
 	)
-	if err := ctx.Engine.RegisterPipeline(pl); err != nil {
-		return fmt.Errorf("register pipeline: %w", err)
+	if err := ctx.Engine.RegisterPipeline(normalPl); err != nil {
+		return fmt.Errorf("register normal pipeline: %w", err)
 	}
+	ctx.Registry.TrackPipeline("signin", normalPipelineID)
 
-	// 跟踪 Pipeline，卸载时自动清理
-	ctx.Registry.TrackPipeline("signin", pipelineID)
+	randomPipelineID := pluginpkg.PipelineID("signin", "random")
+	randomPl := conduit.NewPipelineFromIDs(
+		randomPipelineID,
+		randomExecPassID,
+		randomReplyPassID,
+	)
+	if err := ctx.Engine.RegisterPipeline(randomPl); err != nil {
+		return fmt.Errorf("register random pipeline: %w", err)
+	}
+	ctx.Registry.TrackPipeline("signin", randomPipelineID)
 
-	// 注册行为树子树：签到命令路由
-	subtree := conduit.NewSequence(
-		conduit.NewCondition(isSigninCommand),
-		conduit.NewAction(pipelineID),
+	// ── 注册行为树子树：签到命令路由 ──
+	subtree := conduit.NewSelector(
+		conduit.NewSequence(
+			conduit.NewCondition(isSigninCommand),
+			conduit.NewAction(normalPipelineID),
+		),
+		conduit.NewSequence(
+			conduit.NewCondition(isRandomSigninCommand),
+			conduit.NewAction(randomPipelineID),
+		),
 	)
 	if err := ctx.Engine.RegisterSubtree(pluginpkg.SubtreeID("signin"), subtree); err != nil {
 		return fmt.Errorf("register subtree: %w", err)
@@ -119,54 +160,348 @@ func (p *SigninPlugin) OnStart(_ *pluginpkg.PluginContext) error { return nil }
 func (p *SigninPlugin) OnStop(_ *pluginpkg.PluginContext) error { return nil }
 
 // ============================================================
-// 条件判断
+// RankPlugin 排名插件
 // ============================================================
 
-// isSigninCommand 判断消息是否为签到命令。
-func isSigninCommand(ctx *conduit.MessageContext) bool {
-	return strings.TrimSpace(ctx.RawMsg) == "/签到"
-}
-
-// ============================================================
-// Pass 实现
-// ============================================================
-
-// signinResult 签到结果，Pass 间通过 MessageContext 传递
-type signinResult struct {
-	TodaySigned bool // 今日是否已签到
-	StreakDays  int  // 连续签到天数（含今日）
-	Points      int  // 本次获得积分（已签到时为 0）
-	TotalPoints int  // 累计总积分
-}
-
-const (
-	signinResultKey = "plugin.signin.result" // MessageContext 中签到结果的键
-
-	signinBasePoints    = 10 // 基础签到积分
-	signinStreakBonus   = 2  // 连续签到每天额外积分
-	signinMaxStreakDays = 10 // 连续签到额外积分上限对应天数
-)
-
-// signinExecutePass 执行签到逻辑：读取状态 → 计算积分 → 写入状态
-type signinExecutePass struct {
+// RankPlugin 实现签到积分排行榜功能。
+//
+// 功能：
+//   - /排名 或 /rank：查询积分排行榜 Top 10
+//
+// 行为树：
+//
+//	subtree.signin_rank → Sequence(isRankCommand, Action(pipeline.signin_rank.main))
+//
+// 管线：
+//
+//	pipeline.signin_rank.main → [executePass, replyPass]
+type RankPlugin struct {
 	db     *database.DB
 	store  conduit.StateStore
 	logger *zap.Logger
 }
 
-func (pass *signinExecutePass) Execute(ctx *conduit.MessageContext) error {
+// NewRankPlugin 创建排名插件。
+func NewRankPlugin(db *database.DB, logger *zap.Logger) *RankPlugin {
+	return &RankPlugin{db: db, logger: logger}
+}
+
+// Info 返回排名插件元信息。
+func (p *RankPlugin) Info() pluginpkg.PluginInfo {
+	return pluginpkg.PluginInfo{
+		ID:          "signin_rank",
+		Name:        "签到排行",
+		Description: "签到积分排行榜",
+		Version:     "1.0.0",
+		Commands: []pluginpkg.CommandDef{
+			{Name: "排名", Description: "查看签到积分排行榜"},
+			{Name: "rank", Description: "查看签到积分排行榜"},
+		},
+		SubtreeID: pluginpkg.SubtreeID("signin_rank"),
+		Tools: []pluginpkg.ToolDef{
+			{
+				Name:        "signin_rank",
+				Description: "查询签到积分排行榜",
+				Handler:     p.toolSigninRank,
+			},
+		},
+	}
+}
+
+// OnInit 初始化排名插件，注册 Pass、Pipeline 和 Subtree。
+func (p *RankPlugin) OnInit(ctx *pluginpkg.PluginContext) error {
+	p.db = ctx.DB
+	p.store = ctx.Store
+
+	// ── 注册 Pass ──
+	rankExecPassID := pluginpkg.PassID("signin_rank", "execute")
+	rankReplyPassID := pluginpkg.PassID("signin_rank", "reply")
+	rankExecPass := &signinRankExecutePass{db: p.db, store: p.store, logger: p.logger}
+	rankReplyPass := &signinRankReplyPass{}
+
+	if err := ctx.Engine.RegisterPass(rankExecPassID, rankExecPass); err != nil {
+		return fmt.Errorf("register rank execute pass: %w", err)
+	}
+	if err := ctx.Engine.RegisterPass(rankReplyPassID, rankReplyPass); err != nil {
+		return fmt.Errorf("register rank reply pass: %w", err)
+	}
+	ctx.Registry.TrackPass("signin_rank", rankExecPassID)
+	ctx.Registry.TrackPass("signin_rank", rankReplyPassID)
+
+	// ── 注册管线 ──
+	rankPipelineID := pluginpkg.PipelineID("signin_rank", "main")
+	rankPl := conduit.NewPipelineFromIDs(
+		rankPipelineID,
+		rankExecPassID,
+		rankReplyPassID,
+	)
+	if err := ctx.Engine.RegisterPipeline(rankPl); err != nil {
+		return fmt.Errorf("register rank pipeline: %w", err)
+	}
+	ctx.Registry.TrackPipeline("signin_rank", rankPipelineID)
+
+	// ── 注册行为树子树 ──
+	subtree := conduit.NewSequence(
+		conduit.NewCondition(isRankCommand),
+		conduit.NewAction(rankPipelineID),
+	)
+	if err := ctx.Engine.RegisterSubtree(pluginpkg.SubtreeID("signin_rank"), subtree); err != nil {
+		return fmt.Errorf("register rank subtree: %w", err)
+	}
+
+	return nil
+}
+
+// OnStart 排名插件无需后台任务。
+func (p *RankPlugin) OnStart(_ *pluginpkg.PluginContext) error { return nil }
+
+// OnStop 排名插件无需清理资源。
+func (p *RankPlugin) OnStop(_ *pluginpkg.PluginContext) error { return nil }
+
+// ============================================================
+// 条件判断
+// ============================================================
+
+// isSigninCommand 判断消息是否为普通签到命令。
+func isSigninCommand(ctx *conduit.MessageContext) bool {
+	return strings.TrimSpace(ctx.RawMsg) == "/签到"
+}
+
+// isRandomSigninCommand 判断消息是否为试试手气命令。
+func isRandomSigninCommand(ctx *conduit.MessageContext) bool {
+	return strings.TrimSpace(ctx.RawMsg) == "/试试手气"
+}
+
+// isRankCommand 判断消息是否为排名命令。
+func isRankCommand(ctx *conduit.MessageContext) bool {
+	trimmed := strings.TrimSpace(ctx.RawMsg)
+	return trimmed == "/排名" || trimmed == "/rank"
+}
+
+// ============================================================
+// 签到结果
+// ============================================================
+
+// signinResult 签到结果，Pass 间通过 MessageContext 传递
+type signinResult struct {
+	TodaySigned bool   // 今日是否已签到
+	Points      int    // 本次获得积分（已签到时为 0）
+	TotalPoints int    // 累计总积分
+	Event       string // 随机事件描述
+	Rank        int    // 当前积分排名（-1 表示无排名数据）
+	Mode        string // "normal" 或 "random"
+}
+
+const (
+	signinResultKey = "plugin.signin.result" // MessageContext 中签到结果的键
+
+	signinNormalPoints = 5 // 普通签到固定积分（与上游一致）
+
+	leaderboardKey = "plugin:signin:leaderboard" // 排行榜 StateStore 键
+	leaderboardCap = 100                         // 排行榜最大条目数
+)
+
+// ============================================================
+// 排行榜数据结构
+// ============================================================
+
+// leaderboardEntry 排行榜条目
+type leaderboardEntry struct {
+	UserID      string `json:"user_id"`
+	Nickname    string `json:"nickname"`
+	TotalPoints int    `json:"total_points"`
+}
+
+// updateLeaderboard 更新排行榜中的用户条目
+func updateLeaderboard(store conduit.StateStore, ctx context.Context, userID, nickname string, totalPoints int) {
+	data, _ := store.Get(ctx, leaderboardKey)
+
+	var entries []leaderboardEntry
+	if data != "" {
+		_ = json.Unmarshal([]byte(data), &entries)
+	}
+
+	// 查找并更新用户条目
+	found := false
+	for i := range entries {
+		if entries[i].UserID == userID {
+			entries[i].Nickname = nickname
+			entries[i].TotalPoints = totalPoints
+			found = true
+			break
+		}
+	}
+	if !found {
+		entries = append(entries, leaderboardEntry{
+			UserID:      userID,
+			Nickname:    nickname,
+			TotalPoints: totalPoints,
+		})
+	}
+
+	// 按积分降序排序
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].TotalPoints > entries[j].TotalPoints
+	})
+
+	// 保留前 N 名
+	if len(entries) > leaderboardCap {
+		entries = entries[:leaderboardCap]
+	}
+
+	out, _ := json.Marshal(entries)
+	_ = store.Set(ctx, leaderboardKey, string(out), 0)
+}
+
+// getLeaderboard 读取排行榜数据
+func getLeaderboard(store conduit.StateStore, ctx context.Context) []leaderboardEntry {
+	data, _ := store.Get(ctx, leaderboardKey)
+	if data == "" {
+		return nil
+	}
+	var entries []leaderboardEntry
+	_ = json.Unmarshal([]byte(data), &entries)
+	return entries
+}
+
+// getRank 查询用户在当前排行榜中的排名（1 起），不在榜内返回 -1。
+func getRank(store conduit.StateStore, ctx context.Context, userID string) int {
+	entries := getLeaderboard(store, ctx)
+	for i, e := range entries {
+		if e.UserID == userID {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+// ============================================================
+// 签到事件
+// ============================================================
+
+// signinEvent 事件模板（与上游 LanMei 保持一致）
+type signinEvent struct {
+	Template string   // 句子模板（%s=人物，%s=动作，%v=积分）
+	Persons  []string // 人物
+	Acts     []string // 动作
+}
+
+// 负面事件模板
+var negativeEvents = []signinEvent{
+	{
+		Template: "你被%s狠狠地%s了一顿，扣除了%v积分",
+		Persons:  []string{"同学", "舍友", "学长", "学姐", "朋友"},
+		Acts:     []string{"欺负", "吐槽", "蛐蛐"},
+	},
+	{
+		Template: "你在和%s的%s中败下阵来，扣除了%v积分",
+		Persons:  []string{"同学", "舍友", "学长", "学姐", "朋友"},
+		Acts:     []string{"辩论", "讨论"},
+	},
+	{
+		Template: "%s在背后对你进行了%s，你损失了%v积分",
+		Persons:  []string{"同学", "朋友"},
+		Acts:     []string{"背刺", "吐槽", "打小报告", "挂校园墙"},
+	},
+}
+
+// 正面事件模板
+var positiveEvents = []signinEvent{
+	{
+		Template: "你和%s一起%s，获得了%v积分",
+		Persons:  []string{"同学", "舍友", "学长", "学姐", "朋友"},
+		Acts:     []string{"原神", "三国杀", "鸣潮", "三角洲", "打瓦", "Go", "打篮球", "学习", "讨论代码"},
+	},
+	{
+		Template: "%s偷偷给你%s，心里暖暖的，获得了%v积分",
+		Persons:  []string{"舍友", "朋友", "暗恋对象"},
+		Acts:     []string{"塞了糖", "送早餐", "点了外卖"},
+	},
+	{
+		Template: "你和%s在食堂一起%s，聊得很开心，获得了%v积分",
+		Persons:  []string{"朋友", "舍友", "学长", "学姐"},
+		Acts:     []string{"吃饭", "分享", "打饭"},
+	},
+}
+
+// randomSigninPoints 按概率生成随机签到积分
+//
+//	 2% 概率: -4~4  积分（可能负数）
+//	78% 概率: 4~8   积分
+//	18% 概率: 8~13  积分
+//	 2% 概率: 11~16 积分
+func randomSigninPoints() int {
+	roll := rand.IntN(100) // 0~99
+	switch {
+	case roll < 2: // 2%: -4~4
+		return rand.IntN(9) - 4 // -4 到 4
+	case roll < 80: // 78%: 4~8
+		return rand.IntN(5) + 4 // 4 到 8
+	case roll < 98: // 18%: 8~13
+		return rand.IntN(6) + 8 // 8 到 13
+	default: // 2%: 11~16
+		return rand.IntN(6) + 11 // 11 到 16
+	}
+}
+
+// getEventByPoint 根据积分正负生成随机事件描述（与上游 LanMei 保持一致）。
+// 积分非负时使用正面事件模板，为负时使用负面事件模板（积分取绝对值展示）。
+func getEventByPoint(point int) string {
+	var events []signinEvent
+	if point >= 0 {
+		events = positiveEvents
+	} else {
+		point = -point
+		events = negativeEvents
+	}
+	event := events[rand.IntN(len(events))]
+	person := event.Persons[rand.IntN(len(event.Persons))]
+	act := event.Acts[rand.IntN(len(event.Acts))]
+	return fmt.Sprintf(event.Template, person, act, point)
+}
+
+// ============================================================
+// 通用签到逻辑
+// ============================================================
+
+// ensureUser 确保 StateStore 中的用户记录存在
+func ensureUser(db *database.DB, ctx *conduit.MessageContext) {
+	if db == nil {
+		return
+	}
+	platform, _ := conduit.Get[string](ctx, "platform")
+	if platform == "" {
+		platform = "unknown"
+	}
+	_, _ = db.GetOrCreateUser(ctx.Ctx, platform, ctx.UserID, "")
+}
+
+// nicknameFromCtx 从 MessageContext.Extra 读取用户昵称
+func nicknameFromCtx(ctx *conduit.MessageContext) string {
+	if raw, ok := ctx.Extra["nickname"]; ok {
+		if s, ok := raw.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// ============================================================
+// 普通签到 Pass 实现
+// ============================================================
+
+// signinNormalExecutePass 执行普通签到逻辑：读取状态 → 固定5分 → 事件生成 → 写入状态 → 更新排行榜
+type signinNormalExecutePass struct {
+	db     *database.DB
+	store  conduit.StateStore
+	logger *zap.Logger
+}
+
+func (pass *signinNormalExecutePass) Execute(ctx *conduit.MessageContext) error {
 	now := time.Now()
 	today := now.Format("2006-01-02")
-	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
 
-	// 确保用户存在
-	if pass.db != nil {
-		platform, _ := conduit.Get[string](ctx, "platform")
-		if platform == "" {
-			platform = "unknown"
-		}
-		_, _ = pass.db.GetOrCreateUser(ctx.Ctx, platform, ctx.UserID, "")
-	}
+	ensureUser(pass.db, ctx)
 
 	// 从 StateStore 读取签到记录
 	stateKey := pluginpkg.StoreKey("signin", "state:"+ctx.UserID)
@@ -174,52 +509,48 @@ func (pass *signinExecutePass) Execute(ctx *conduit.MessageContext) error {
 	if err != nil {
 		pass.logger.Warn("signin: failed to read last sign-in date", zap.String("user", ctx.UserID), zap.Error(err))
 	}
-	streakDays := storeGetInt(pass.store, ctx.Ctx, stateKey+":streak")
 	totalPoints := storeGetInt(pass.store, ctx.Ctx, stateKey+":total")
 
 	// 检查今日是否已签到
 	todaySigned := lastDate == today
 
-	// 检查连续性：如果上次签到不是昨天也不是今天，重置连续天数
-	if lastDate != "" && lastDate != today && lastDate != yesterday {
-		streakDays = 0
-	}
-
-	// 计算本次签到
+	// 计算本次签到（固定 5 积分，与上游一致）
 	var points int
+	var event string
 	if !todaySigned {
-		streakDays++
-		bonus := min(streakDays-1, signinMaxStreakDays) * signinStreakBonus
-		points = signinBasePoints + bonus
+		points = signinNormalPoints
 		totalPoints += points
+		event = getEventByPoint(points)
 
 		// 更新 StateStore
 		if err := pass.store.Set(ctx.Ctx, stateKey+":date", today, 0); err != nil {
 			pass.logger.Error("signin: failed to save sign-in date", zap.String("user", ctx.UserID), zap.Error(err))
 		}
-		if err := pass.store.Set(ctx.Ctx, stateKey+":streak", fmt.Sprintf("%d", streakDays), 0); err != nil {
-			pass.logger.Error("signin: failed to save streak days", zap.String("user", ctx.UserID), zap.Error(err))
-		}
 		if err := pass.store.Set(ctx.Ctx, stateKey+":total", fmt.Sprintf("%d", totalPoints), 0); err != nil {
 			pass.logger.Error("signin: failed to save total points", zap.String("user", ctx.UserID), zap.Error(err))
 		}
+
+		// 更新排行榜
+		updateLeaderboard(pass.store, ctx.Ctx, ctx.UserID, nicknameFromCtx(ctx), totalPoints)
 	}
 
-	// 将结果写入 MessageContext，供 replyPass 使用
+	// 将结果写入 MessageContext
 	conduit.Set(ctx, signinResultKey, &signinResult{
 		TodaySigned: todaySigned,
-		StreakDays:  streakDays,
 		Points:      points,
 		TotalPoints: totalPoints,
+		Event:       event,
+		Rank:        getRank(pass.store, ctx.Ctx, ctx.UserID),
+		Mode:        "normal",
 	})
 
 	return nil
 }
 
-// signinReplyPass 组装签到回复消息
-type signinReplyPass struct{}
+// signinNormalReplyPass 组装普通签到回复消息
+type signinNormalReplyPass struct{}
 
-func (pass *signinReplyPass) Execute(ctx *conduit.MessageContext) error {
+func (pass *signinNormalReplyPass) Execute(ctx *conduit.MessageContext) error {
 	result, ok := conduit.Get[*signinResult](ctx, signinResultKey)
 	if !ok {
 		conduit.AppendOutput(ctx, &conduit.Message{
@@ -231,11 +562,11 @@ func (pass *signinReplyPass) Execute(ctx *conduit.MessageContext) error {
 
 	var content string
 	if result.TodaySigned {
-		content = fmt.Sprintf("今日已签到~\n连续签到: %d天\n累计积分: %d",
-			result.StreakDays, result.TotalPoints)
+		content = fmt.Sprintf("今天已经签到过了，请明天再来吧~\n目前你积分为%d\n排名第%d位",
+			result.TotalPoints, result.Rank)
 	} else {
-		content = fmt.Sprintf("签到成功！\n连续签到: %d天\n本次积分: +%d\n累计积分: %d",
-			result.StreakDays, result.Points, result.TotalPoints)
+		content = fmt.Sprintf("签到成功，%s。\n目前你积分为%d\n排名第%d位",
+			result.Event, result.TotalPoints, result.Rank)
 	}
 
 	conduit.AppendOutput(ctx, &conduit.Message{
@@ -246,16 +577,186 @@ func (pass *signinReplyPass) Execute(ctx *conduit.MessageContext) error {
 }
 
 // ============================================================
-// 辅助函数
+// 随机签到 Pass 实现
 // ============================================================
 
-// parseUserID64 将字符串用户 ID 解析为 int64
-// 已废弃，仅用于向后兼容
-func parseUserID64(s string) int64 {
-	var id int64
-	fmt.Sscanf(s, "%d", &id)
-	return id
+// signinRandomExecutePass 执行试试手气签到逻辑：读取状态 → 随机积分 → 事件生成 → 写入状态 → 更新排行榜
+type signinRandomExecutePass struct {
+	db     *database.DB
+	store  conduit.StateStore
+	logger *zap.Logger
 }
+
+func (pass *signinRandomExecutePass) Execute(ctx *conduit.MessageContext) error {
+	now := time.Now()
+	today := now.Format("2006-01-02")
+
+	ensureUser(pass.db, ctx)
+
+	// 从 StateStore 读取签到记录（与普通签到共享状态）
+	stateKey := pluginpkg.StoreKey("signin", "state:"+ctx.UserID)
+	lastDate, err := pass.store.Get(ctx.Ctx, stateKey+":date")
+	if err != nil {
+		pass.logger.Warn("signin: failed to read last sign-in date", zap.String("user", ctx.UserID), zap.Error(err))
+	}
+	totalPoints := storeGetInt(pass.store, ctx.Ctx, stateKey+":total")
+
+	// 检查今日是否已签到
+	todaySigned := lastDate == today
+
+	// 计算本次随机签到
+	var points int
+	var event string
+	if !todaySigned {
+		points = randomSigninPoints()
+		totalPoints += points
+
+		// 如果负数积分导致总积分低于 0，限制为 0
+		if totalPoints < 0 {
+			totalPoints = 0
+		}
+
+		// 生成随机事件描述
+		event = getEventByPoint(points)
+
+		// 更新 StateStore
+		if err := pass.store.Set(ctx.Ctx, stateKey+":date", today, 0); err != nil {
+			pass.logger.Error("signin: failed to save sign-in date", zap.String("user", ctx.UserID), zap.Error(err))
+		}
+		if err := pass.store.Set(ctx.Ctx, stateKey+":total", fmt.Sprintf("%d", totalPoints), 0); err != nil {
+			pass.logger.Error("signin: failed to save total points", zap.String("user", ctx.UserID), zap.Error(err))
+		}
+
+		// 更新排行榜
+		updateLeaderboard(pass.store, ctx.Ctx, ctx.UserID, nicknameFromCtx(ctx), totalPoints)
+	}
+
+	// 将结果写入 MessageContext
+	conduit.Set(ctx, signinResultKey, &signinResult{
+		TodaySigned: todaySigned,
+		Points:      points,
+		TotalPoints: totalPoints,
+		Event:       event,
+		Rank:        getRank(pass.store, ctx.Ctx, ctx.UserID),
+		Mode:        "random",
+	})
+
+	return nil
+}
+
+// signinRandomReplyPass 组装试试手气签到回复消息
+type signinRandomReplyPass struct{}
+
+func (pass *signinRandomReplyPass) Execute(ctx *conduit.MessageContext) error {
+	result, ok := conduit.Get[*signinResult](ctx, signinResultKey)
+	if !ok {
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "签到状态异常，请重试。",
+		})
+		return nil
+	}
+
+	var content string
+	if result.TodaySigned {
+		content = fmt.Sprintf("今天已经签到过了，请明天再来吧~\n目前你积分为%d\n排名第%d位",
+			result.TotalPoints, result.Rank)
+	} else {
+		content = fmt.Sprintf("签到成功，%s。\n目前你积分为%d\n排名第%d位",
+			result.Event, result.TotalPoints, result.Rank)
+	}
+
+	conduit.AppendOutput(ctx, &conduit.Message{
+		UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+		Content: content,
+	})
+	return nil
+}
+
+// ============================================================
+// 排名 Pass 实现
+// ============================================================
+
+// rankResult 排名查询结果
+type rankEntry struct {
+	Rank        int    `json:"rank"`
+	UserID      string `json:"user_id"`
+	Nickname    string `json:"nickname"`
+	TotalPoints int    `json:"total_points"`
+}
+
+const rankResultKey = "plugin.signin.rank_result"
+
+// signinRankExecutePass 执行排名查询：从 StateStore 读取排行榜 → 取 Top 10
+type signinRankExecutePass struct {
+	db     *database.DB
+	store  conduit.StateStore
+	logger *zap.Logger
+}
+
+func (pass *signinRankExecutePass) Execute(ctx *conduit.MessageContext) error {
+	entries := getLeaderboard(pass.store, ctx.Ctx)
+
+	// 补充昵称：如果排行榜中昵称为空，尝试从数据库获取
+	top := entries
+	if len(top) > 10 {
+		top = top[:10]
+	}
+
+	rankEntries := make([]rankEntry, 0, len(top))
+	for i, e := range top {
+		nickname := e.Nickname
+		if nickname == "" {
+			nickname = e.UserID
+		}
+		rankEntries = append(rankEntries, rankEntry{
+			Rank:        i + 1,
+			UserID:      e.UserID,
+			Nickname:    nickname,
+			TotalPoints: e.TotalPoints,
+		})
+	}
+
+	conduit.Set(ctx, rankResultKey, rankEntries)
+	return nil
+}
+
+// signinRankReplyPass 组装排名回复消息
+type signinRankReplyPass struct{}
+
+func (pass *signinRankReplyPass) Execute(ctx *conduit.MessageContext) error {
+	rankEntries, ok := conduit.Get[[]rankEntry](ctx, rankResultKey)
+	if !ok || len(rankEntries) == 0 {
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "暂无签到排行数据~",
+		})
+		return nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("🏆 签到积分排行榜\n")
+	sb.WriteString("──────────────\n")
+	for _, e := range rankEntries {
+		// 显示昵称，截断过长的昵称
+		name := e.Nickname
+		if len(name) > 10 {
+			name = name[:10] + "…"
+		}
+		sb.WriteString(fmt.Sprintf("%d. %s — %d积分\n", e.Rank, name, e.TotalPoints))
+	}
+	sb.WriteString("──────────────")
+
+	conduit.AppendOutput(ctx, &conduit.Message{
+		UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+		Content: sb.String(),
+	})
+	return nil
+}
+
+// ============================================================
+// 辅助函数
+// ============================================================
 
 // storeGetInt 从 StateStore 读取整数值
 func storeGetInt(store conduit.StateStore, ctx context.Context, key string) int {
@@ -268,7 +769,11 @@ func storeGetInt(store conduit.StateStore, ctx context.Context, key string) int 
 	return n
 }
 
-// toolSigninStatus 是 AI 工具处理器，查询用户签到状态和积分。
+// ============================================================
+// AI 工具处理器
+// ============================================================
+
+// toolSigninStatus 查询用户签到状态和积分
 func (p *SigninPlugin) toolSigninStatus(ctx context.Context, argsJSON string) (string, error) {
 	var args struct {
 		UserID string `json:"user_id"`
@@ -279,9 +784,68 @@ func (p *SigninPlugin) toolSigninStatus(ctx context.Context, argsJSON string) (s
 
 	stateKey := pluginpkg.StoreKey("signin", "state:"+args.UserID)
 	lastDate, _ := p.store.Get(ctx, stateKey+":date")
-	streakDays := storeGetInt(p.store, ctx, stateKey+":streak")
 	totalPoints := storeGetInt(p.store, ctx, stateKey+":total")
 
-	return fmt.Sprintf("用户 %s: 最后签到日期=%s, 连续天数=%d, 累计积分=%d",
-		args.UserID, lastDate, streakDays, totalPoints), nil
+	return fmt.Sprintf("用户 %s: 最后签到日期=%s, 累计积分=%d",
+		args.UserID, lastDate, totalPoints), nil
+}
+
+// toolSigninRandom 帮用户试试手气
+func (p *SigninPlugin) toolSigninRandom(ctx context.Context, argsJSON string) (string, error) {
+	var args struct {
+		UserID string `json:"user_id"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return "", fmt.Errorf("参数解析失败: %w", err)
+	}
+
+	now := time.Now()
+	today := now.Format("2006-01-02")
+
+	stateKey := pluginpkg.StoreKey("signin", "state:"+args.UserID)
+	lastDate, _ := p.store.Get(ctx, stateKey+":date")
+	totalPoints := storeGetInt(p.store, ctx, stateKey+":total")
+
+	if lastDate == today {
+		return fmt.Sprintf("用户 %s 今日已签到，累计%d积分",
+			args.UserID, totalPoints), nil
+	}
+
+	points := randomSigninPoints()
+	totalPoints += points
+	if totalPoints < 0 {
+		totalPoints = 0
+	}
+
+	event := getEventByPoint(points)
+
+	_ = p.store.Set(ctx, stateKey+":date", today, 0)
+	_ = p.store.Set(ctx, stateKey+":total", fmt.Sprintf("%d", totalPoints), 0)
+
+	return fmt.Sprintf("用户 %s 试试手气: %s (积分%+d, 累计%d积分)",
+		args.UserID, event, points, totalPoints), nil
+}
+
+// toolSigninRank 查询签到积分排行榜
+func (p *RankPlugin) toolSigninRank(ctx context.Context, argsJSON string) (string, error) {
+	entries := getLeaderboard(p.store, ctx)
+	if len(entries) == 0 {
+		return "暂无签到排行数据", nil
+	}
+
+	top := entries
+	if len(top) > 10 {
+		top = top[:10]
+	}
+
+	var parts []string
+	for i, e := range top {
+		name := e.Nickname
+		if name == "" {
+			name = e.UserID
+		}
+		parts = append(parts, fmt.Sprintf("%d. %s(%d积分)", i+1, name, e.TotalPoints))
+	}
+
+	return "签到排行榜: " + strings.Join(parts, ", "), nil
 }

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/rand/v2"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -452,6 +453,7 @@ func (b *Bot) calcSegmentInterval(text string) time.Duration {
 
 // reply 通过网关回复消息。
 // 发送前执行回复限流（群配额 + 全局配额），超限时静默丢弃，防止 Bot 刷屏。
+// 回复内容为纯 http(s) URL 时按图片消息发送（富媒体段），供 cat/balogo/github_card 等图片类插件使用。
 func (b *Bot) reply(msg *gateway.NormalizedMessage, text string) {
 	ctx := context.Background()
 	if b.limiter != nil {
@@ -461,7 +463,27 @@ func (b *Bot) reply(msg *gateway.NormalizedMessage, text string) {
 			return
 		}
 	}
+	if isImageURL(text) {
+		// 纯 URL → 图片消息（走上游富媒体发送体系）
+		if err := b.gw.Hub().SendSegments(msg.ConnID, msg, []gateway.NormalizedSegment{{
+			Type: "image",
+			Data: map[string]string{"url": strings.TrimSpace(text)},
+		}}); err != nil {
+			b.logger.Error("bot: 图片回复失败", zap.String("conn", msg.ConnID), zap.Error(err))
+		}
+		return
+	}
 	if err := b.gw.Hub().SendMessageTo(msg.ConnID, msg, text); err != nil {
 		b.logger.Error("bot: 回复失败", zap.String("conn", msg.ConnID), zap.Error(err))
 	}
+}
+
+// isImageURL 判断文本是否为纯图片 URL。
+// 规则：去除首尾空白后是完整的 http(s) URL（不含内部空格/换行）。
+func isImageURL(text string) bool {
+	t := strings.TrimSpace(text)
+	if !strings.HasPrefix(t, "http://") && !strings.HasPrefix(t, "https://") {
+		return false
+	}
+	return !strings.ContainsAny(t, " \t\n\r")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,11 @@ type Config struct {
 type PluginConfig struct {
 	// RootDir Wasm 插件根目录
 	RootDir string `mapstructure:"root_dir"`
+
+	// NCMURL 网易云音乐 API 服务地址（网易云点歌插件使用）。
+	// 为空时点歌插件不可用；格式如 http://ncm-api:3000
+	NCMURL string `mapstructure:"ncm_url"`
+
 	// Builtins 内置业务插件开关（配置驱动注册，替代 main.go 硬编码注册）
 	Builtins PluginBuiltinsConfig `mapstructure:"builtins"`
 }
@@ -33,6 +38,18 @@ type PluginBuiltinsConfig struct {
 	Signin bool `mapstructure:"signin"`
 	// Welcome 入群欢迎插件
 	Welcome bool `mapstructure:"welcome"`
+	// Rank 签到积分排行榜插件
+	Rank bool `mapstructure:"rank"`
+	// Cat 猫猫图片插件
+	Cat bool `mapstructure:"cat"`
+	// BaLogo 蔚蓝档案 LOGO 插件
+	BaLogo bool `mapstructure:"balogo"`
+	// Ping 连通性测试插件
+	Ping bool `mapstructure:"ping"`
+	// GitHubCard GitHub 链接卡片插件
+	GitHubCard bool `mapstructure:"github_card"`
+	// Music 网易云点歌插件
+	Music bool `mapstructure:"music"`
 }
 
 // DatabaseConfig 数据库配置

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -65,6 +65,7 @@ func Init() (*Config, error) {
 		"LANMEI_AI_EMBEDDING_MODEL":          "ai.embedding_model",
 		"LANMEI_AI_EMBEDDING_DIM":            "ai.embedding_dim",
 		"LANMEI_PLUGIN_ROOT_DIR":             "plugin.root_dir",
+		"LANMEI_PLUGIN_NCM_URL":              "plugin.ncm_url",
 		"LANMEI_KNOWLEDGE_ENABLED":           "knowledge.enabled",
 		"LANMEI_KNOWLEDGE_AUTO_RECALL_LIMIT": "knowledge.auto_recall_limit",
 		// 多媒体（RustFS）与机器人行为配置
@@ -110,6 +111,7 @@ func initFlags() {
 	pflag.Int("log.max_age", 0, "日志文件最大保留天数")
 	pflag.Int("log.max_backups", 0, "最多保留的旧日志文件数")
 	pflag.String("plugin.root_dir", "", "Wasm 插件根目录")
+	pflag.String("plugin.ncm_url", "", "网易云音乐 API 服务地址（点歌插件）")
 	// Prompts 路径
 	pflag.String("prompts.dir", "", "Prompt 系统目录")
 	pflag.String("prompts.config", "", "Prompt 配置文件路径")
@@ -167,6 +169,7 @@ func setDefaults(v *viper.Viper) {
 
 	// Plugin 默认值
 	v.SetDefault("plugin.root_dir", "./data/plugins")
+	v.SetDefault("plugin.ncm_url", "")
 
 	// Prompts 默认路径
 	v.SetDefault("prompts.dir", "./prompts")


### PR DESCRIPTION
## 内容
移植上游 LanMei 的 7 个插件并适配本项目 Conduit 架构：

| 插件 | 功能 |
|---|---|
| 试试手气 | 随机积分 + 事件描述（概率分布与上个蓝妹一致）|
| 排名 | 签到积分排行榜 Top10 |
| 网易云点歌 | /music 搜索 + 序号点歌，会话 60s |
| GitHub卡片 | 检测 GitHub 链接自动返回 OpenGraph 卡片 |
| 猫猫 | /猫猫 /哈基米 HTTP Cat 图片 |
| BA-LOGO | /balogo 外链生成 BA 风格 LOGO |
| Ping | /ping → Pong |
## 配置
- `LANMEI_PLUGIN_NCM_URL` 网易云点歌 API（可选）