### PR TITLE
feat: 网关发送出口支持富文本（事件回调升级为 makeRichContentCallback）

### DIFF
--- a/internal/bizplugin/README.md
+++ b/internal/bizplugin/README.md
@@ -28,7 +28,7 @@ NormalizedMessage（+ EventType / EventSubType / EventData）
   │  ③ 插件子树（第一层，优先）← 事件类插件在这里消费
   │     （未被插件接住的事件会继续滑向后继分支直至意图分析——因此事件插件必须存在）
   ▼
-插件管线 → AppendOutput → makeEventCallback → 网关发回群
+插件管线 → AppendOutput → makeRichContentCallback → 网关发回群
 ```
 
 ### 1. 上游：事件接收通道（gateway 层，一般无需改动）
@@ -49,7 +49,7 @@ NormalizedMessage（+ EventType / EventSubType / EventData）
 | `bot.event.sub_type` | string | 事件子类型，如 `approve` / `invite` |
 | `bot.event.data` | map[string]any | 事件全字段（user_id / group_id / operator_id / sub_type 等）|
 
-事件消息由事件专用回调 `makeEventCallback` 处理：处理出错只记日志不回复；正常完成时遍历输出发送（插件的欢迎文案由此发出）。
+事件消息由富文本发送回调 `makeRichContentCallback` 处理：处理出错只记日志不回复；正常完成时若插件写入了富文本键 `bot.rich.content`（map：`text` / `at` / `image`，见 `internal/bot/passes.go` 的 `KeyRichContent`）则按富文本发送，否则遍历输出发送纯文本（插件的欢迎文案由此发出）。
 
 ### 3. 下游：插件消费（本包，以 welcome 为模范示例）
 
@@ -182,4 +182,4 @@ go run ./cmd/lanmei
 - `github.com/zrurf/conduit` — 引擎、行为树、管线（`MessageContext.Extra` 即黑板）
 - `internal/gateway` — 事件归一化与事件键契约（`notice.go`、`message.go`）
 - `internal/plugin` — 插件接口与资源注册（`PluginContext` / `PassID` / `PipelineID` / `StoreKey`）
-- `internal/bot` — 事件写入黑板（`OnMessage` 分流、`makeEventCallback`、事件键定义）
+- `internal/bot` — 事件写入黑板（`OnMessage` 分流、`makeRichContentCallback`、事件键定义）

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -309,7 +309,7 @@ func (b *Bot) OnMessage(msg *gateway.NormalizedMessage) {
 	// 事件消息（notice/request）：出错也绝不向群里发消息（事件落空发"迷糊话术"是 bug）
 	isEvent := msg.MessageType == gateway.MessageTypeNotice || msg.MessageType == gateway.MessageTypeRequest
 	if isEvent {
-		input.ResponseCallback = b.makeEventCallback(msg)
+		input.ResponseCallback = b.makeRichContentCallback(msg)
 	} else {
 		input.ResponseCallback = b.makeResponseCallback(msg)
 	}
@@ -322,9 +322,11 @@ func (b *Bot) OnMessage(msg *gateway.NormalizedMessage) {
 	}
 }
 
-// makeEventCallback 构造通知事件专用回调：事件处理出错时只记日志、绝不回复；
-// 正常完成时遍历 Output 发送（供未来事件消费插件写入输出，如入群欢迎）。
-func (b *Bot) makeEventCallback(msg *gateway.NormalizedMessage) func(*conduit.MessageContext, error) {
+// makeRichContentCallback 构造富文本发送回调，与 makeResponseCallback 平级：
+// 插件经富文本键（KeyRichContent）输出 "文本 + @ + 图片" 组合消息时按富文本发送；
+// 未提供富文本内容时遍历 Output 发送纯文本（兼容原事件回调行为）。
+// 处理出错时只记日志、绝不回复（事件保持静默，不向群里发消息）。
+func (b *Bot) makeRichContentCallback(msg *gateway.NormalizedMessage) func(*conduit.MessageContext, error) {
 	return func(ctx *conduit.MessageContext, err error) {
 		if err != nil {
 			b.logger.Error("bot: event process failed",
@@ -334,10 +336,58 @@ func (b *Bot) makeEventCallback(msg *gateway.NormalizedMessage) func(*conduit.Me
 			)
 			return
 		}
+		if content, ok := richContentFromCtx(ctx); ok {
+			if !b.replyAllowed(msg) {
+				return
+			}
+			if err := b.gw.Hub().SendRichContent(msg.ConnID, msg, content); err != nil {
+				b.logger.Error("bot: 富文本回复失败", zap.String("conn", msg.ConnID), zap.Error(err))
+			}
+			return
+		}
 		for _, out := range ctx.Output {
 			b.reply(msg, out.Content)
 		}
 	}
+}
+
+// richContentFromCtx 读取插件写入的富文本发送内容（KeyRichContent）。
+// 键不存在、类型不符或内容全空时返回 false，调用方走纯文本兜底。
+func richContentFromCtx(ctx *conduit.MessageContext) (gateway.RichContent, bool) {
+	raw, ok := conduit.Get[map[string]any](ctx, KeyRichContent)
+	if !ok {
+		return gateway.RichContent{}, false
+	}
+	content := gateway.RichContent{}
+	if v, ok := raw["text"].(string); ok {
+		content.Text = v
+	}
+	if v, ok := raw["at"].(string); ok {
+		content.At = v
+	}
+	if v, ok := raw["image"].(string); ok {
+		content.Image = v
+	}
+	// 内容全空视为无效（如键名写错/空 map），交由调用方走纯文本兜底
+	if content.Text == "" && content.At == "" && content.Image == "" {
+		return gateway.RichContent{}, false
+	}
+	return content, true
+}
+
+// replyAllowed 检查回复限流（群配额 + 全局配额），超限时静默丢弃返回 false。
+// limiter 为 nil 时放行。
+func (b *Bot) replyAllowed(msg *gateway.NormalizedMessage) bool {
+	if b.limiter == nil {
+		return true
+	}
+	ctx := context.Background()
+	if !b.limiter.AllowGroupReply(ctx, msg.GroupID) || !b.limiter.AllowTotalReply(ctx) {
+		b.logger.Debug("bot: 回复限流，静默丢弃",
+			zap.String("group", msg.GroupID), zap.String("conn", msg.ConnID))
+		return false
+	}
+	return true
 }
 
 // makeResponseCallback 构造消息级回调，处理两种情况：

--- a/internal/bot/passes.go
+++ b/internal/bot/passes.go
@@ -37,6 +37,9 @@ const (
 	KeyImageDesc    = "bot.image_desc"    // string 图片理解描述
 	KeyMediaHandled = "bot.media_handled" // bool 媒体已处理（RouterPass 路由依据）
 
+	// ── 富文本输出（data，插件经 conduit.Set 写入，makeRichContentCallback 读取）──
+	KeyRichContent = "bot.rich.content" // map[string]any{text/at/image} 富文本发送内容（无键走纯文本）
+
 	// ── 群聊话题（TopicGatePass 写入，供对话管线消费）──
 	KeyTopicID      = "bot.topic.id"      // string 命中话题 ID（data）
 	KeyTopicLabel   = "bot.topic.label"   // string 话题描述（data）

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -127,6 +127,20 @@ func (h *Hub) SendAtText(connID string, msg *NormalizedMessage, atUserID, text s
 	return h.SendSegments(connID, msg, segs)
 }
 
+// SendRichContent 向指定连接发送富文本消息（文本 + 可选 @ + 可选图片，自动选择协议动作）。
+// content.At 为空时不 @，content.Image 为空时不发图。
+func (h *Hub) SendRichContent(connID string, msg *NormalizedMessage, content RichContent) error {
+	segs := make([]NormalizedSegment, 0, 3)
+	if content.At != "" {
+		segs = append(segs, NormalizedSegment{Type: "at", Data: map[string]string{"user_id": content.At}})
+	}
+	segs = append(segs, NormalizedSegment{Type: "text", Text: content.Text})
+	if content.Image != "" {
+		segs = append(segs, NormalizedSegment{Type: "image", Data: map[string]string{"file": content.Image}})
+	}
+	return h.SendSegments(connID, msg, segs)
+}
+
 // All 返回所有活跃连接的快照
 func (h *Hub) All() []*Connection {
 	h.mu.RLock()

--- a/internal/gateway/message.go
+++ b/internal/gateway/message.go
@@ -593,6 +593,16 @@ func ToMessageSegmentV11(segs []NormalizedSegment) []MessageSegmentV11 {
 	return result
 }
 
+// ── 富文本发送内容 ──
+
+// RichContent 富文本发送内容：一段文本 + 可选 @ 用户 + 可选图片。
+// At / Image 为空时对应消息段不生成（空 At = 不 @，空 Image = 不发图）。
+type RichContent struct {
+	Text  string // 文本内容
+	At    string // @ 目标用户 ID（空 = 不 @）
+	Image string // 图片 file（URL / 本地路径 / base64，空 = 不发图）
+}
+
 // ── 辅助函数 ──
 
 // formatIntOrString 将值格式化为字符串（处理 JSON number 或 string）


### PR DESCRIPTION
## 背景

- 同步上游 main（eaf8ef1，PR #15 已实现 `hub.SendSegments` 等富媒体发送链路）
- 本 PR 补齐 bot 层发送出口的富文本支持，为后续 welcome 插件升级（@新人 + 文本 + 图片）铺路

## 改动

1. **gateway/hub.go**：新增 `SendRichContent`（RichContent → 段列表 → 委托现有 `SendSegments`，v11 的 at 段 user_id→qq 转换由 `ToMessageSegmentV11` 处理）
2. **gateway/message.go**：新增 `RichContent{Text, At, Image}` 富文本发送内容结构体（At/Image 空则不发对应段）
3. **bot/bot.go**：`makeEventCallback` → `makeRichContentCallback`（与 `makeResponseCallback` 平级），支持插件经 `bot.rich.content` 键输出富文本；无键/内容全空/类型不符时走原纯文本路径；补回复限流
4. **bot/passes.go**：新增 `KeyRichContent = "bot.rich.content"` 键常量
5. **bizplugin/README.md**：同步回调名

## 兼容性

- `makeResponseCallback`、`hub.SendMessageTo`、`BuildSendMessageV12/V11` 一行未动
- signin/welcome 等现有插件零影响（无富文本键走原路径）

## 验证

- `go build ./...` + `go vet ./...` 通过
- 实测（docker PG/Redis + 蓝妹 + WS 脚本）：
  - v12/v11 入群事件回归：welcome 纯文本回发正常
  - 临时 verify 程序（验证后已删）走真实链路：v12 回发 `[at(user_id), text, image]`；v11 回发 `[at(qq), text, image]` + `send_group_msg`