### PR TITLE
feat: 添加动态管理员功能

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/rand/v2"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -39,7 +41,9 @@ type Bot struct {
 	minIntervalMS   int                            // 最小发送间隔（毫秒）
 	maxIntervalMS   int                            // 最大发送间隔（毫秒），0 不限
 	jitterPct       float64                        // 间隔抖动比例（0.0-1.0）
-	superUsers      map[string]map[string]struct{} // 超管集合：平台 → 用户ID
+	superUsers      map[string]map[string]struct{} // 超管集合：平台 → 用户ID（静态配置 + 动态添加合并）
+	adminMu         sync.RWMutex                   // 保护 superUsers 的并发读写
+	db              *database.DB                   // 数据库访问（动态管理员持久化；nil 时动态添加不可用）
 	stickerInjector StickerEmotionInjector         // 硬性表情规则注入器（表情库插件，nil 表示未启用）
 	stickerCount    int                            // 已回复消息计数（硬性表情规则）
 	stickerTarget   int                            // 触发阈值（10~20 随机，0 表示首次回复前未初始化）
@@ -254,7 +258,7 @@ func New(cfg *config.BotConfig, cmdSys *command.System, chatSvc *ai.ChatService,
 	bt := buildBehaviorTree(pluginReg, coreAdmin, coreCommand, coreIntent, coreSegment, coreNotice, coreMedia)
 	engine.SetBehaviorTree(bt)
 
-	return &Bot{
+	b := &Bot{
 		engine:        engine,
 		plugins:       pluginReg,
 		gw:            gwServer,
@@ -267,18 +271,139 @@ func New(cfg *config.BotConfig, cmdSys *command.System, chatSvc *ai.ChatService,
 		maxIntervalMS: cfg.Stream.MaxIntervalMS,
 		jitterPct:     cfg.Stream.JitterPct,
 		superUsers:    parseSuperUsers(cfg.SuperUsers),
+		db:            db,
 		objectStore:   mediaStore,
 		logger:        logger,
 	}
+
+	// 合并持久化的动态管理员（重启不丢）并注册管理员命令
+	b.loadDynamicAdmins()
+	b.registerAdminCommands()
+
+	return b
 }
 
-// isSuperUser 判断 (platform, userID) 是否在超管集合中。
+// isSuperUser 判断 (platform, userID) 是否在超管集合中（静态配置 + 动态添加合并，并发安全）。
 func (b *Bot) isSuperUser(platform, userID string) bool {
+	b.adminMu.RLock()
+	defer b.adminMu.RUnlock()
 	if m, ok := b.superUsers[platform]; ok {
 		_, ok := m[userID]
 		return ok
 	}
 	return false
+}
+
+// AddSuperUser 向内存超管集合添加一个成员（并发安全）。
+// 调用方需先完成持久化，保证内存与存储一致。
+func (b *Bot) AddSuperUser(platform, userID string) {
+	if platform == "" || userID == "" {
+		return
+	}
+	b.adminMu.Lock()
+	defer b.adminMu.Unlock()
+	if b.superUsers[platform] == nil {
+		b.superUsers[platform] = map[string]struct{}{}
+	}
+	b.superUsers[platform][userID] = struct{}{}
+}
+
+// loadDynamicAdmins 启动时从 bot_admin 表加载动态管理员并入内存集合。
+// DB 不可用时仅记录错误（静态配置超管不受影响），不阻断启动。
+func (b *Bot) loadDynamicAdmins() {
+	if b.db == nil {
+		return
+	}
+	admins, err := b.db.ListAdmins(context.Background())
+	if err != nil {
+		b.logger.Error("bot: 加载动态管理员失败", zap.Error(err))
+		return
+	}
+	for _, a := range admins {
+		b.AddSuperUser(a.Platform, a.UserID)
+	}
+	if len(admins) > 0 {
+		b.logger.Info("bot: 动态管理员已加载", zap.Int("count", len(admins)))
+	}
+}
+
+// ── 管理员管理命令 ──
+
+// registerAdminCommands 注册管理员管理命令（/添加管理员）。
+func (b *Bot) registerAdminCommands() {
+	_ = b.cmdSys.Register(command.Command{
+		Name:        "添加管理员",
+		Description: "添加管理员（仅超管），格式：/添加管理员 [平台:]用户ID，如 /添加管理员 qq:123456",
+		Handler:     b.handleAddAdmin,
+	})
+}
+
+// handleAddAdmin 处理 /添加管理员：
+// 超管校验 → 解析 [平台:]用户ID → 幂等写库 → 更新内存集合。
+// 顺序保证一致性：先持久化成功再更新内存，DB 失败则内存不变。
+func (b *Bot) handleAddAdmin(cmdCtx *command.Context) error {
+	if !cmdCtx.IsSuperUser {
+		cmdCtx.Reply("只有管理员才能添加管理员哦~")
+		return nil
+	}
+	if b.db == nil {
+		cmdCtx.Reply("数据库不可用，无法添加管理员")
+		return nil
+	}
+
+	platform, userID, err := parseAdminArg(cmdCtx)
+	if err != nil {
+		cmdCtx.Reply(err.Error())
+		return nil
+	}
+
+	existed, err := b.db.AddAdmin(context.Background(), platform, userID,
+		cmdCtx.Platform+":"+cmdCtx.PlatformUserID)
+	if err != nil {
+		b.logger.Error("bot: 添加管理员写库失败",
+			zap.String("platform", platform), zap.String("user", userID), zap.Error(err))
+		cmdCtx.Reply("添加管理员失败，请稍后重试")
+		return nil
+	}
+	// 写库成功（或已存在）后再更新内存集合，保证内存与存储一致
+	b.AddSuperUser(platform, userID)
+	if existed {
+		cmdCtx.Reply(fmt.Sprintf("%s:%s 已经是管理员啦", platform, userID))
+		return nil
+	}
+	cmdCtx.Reply(fmt.Sprintf("已添加管理员 ✅ %s:%s", platform, userID))
+	return nil
+}
+
+// knownPlatforms 合法平台标识（与 gateway.Platform 常量保持一致）。
+var knownPlatforms = map[string]struct{}{"qq": {}, "napcat": {}, "wechat": {}, "telegram": {}}
+
+// parseAdminArg 解析 /添加管理员 参数：[平台:]用户ID。
+//   - 带冒号（如 "qq:123456"）：校验平台合法性；
+//   - 裸用户ID（如 "123456"）：默认取当前消息平台；当前平台未知（unknown）时要求显式带平台前缀。
+func parseAdminArg(cmdCtx *command.Context) (platform, userID string, err error) {
+	raw := strings.TrimSpace(strings.Join(cmdCtx.CommandArgs, " "))
+	if raw == "" {
+		return "", "", errors.New("格式错误！用法：/添加管理员 [平台:]用户ID，如 /添加管理员 qq:123456")
+	}
+	if strings.Contains(raw, ":") {
+		parts := strings.SplitN(raw, ":", 2)
+		platform = strings.TrimSpace(parts[0])
+		userID = strings.TrimSpace(parts[1])
+		if _, ok := knownPlatforms[platform]; !ok {
+			return "", "", fmt.Errorf("未知平台「%s」，支持 qq/napcat/wechat/telegram", platform)
+		}
+	} else {
+		platform = cmdCtx.Platform
+		userID = strings.TrimSpace(raw)
+		if _, ok := knownPlatforms[platform]; !ok {
+			return "", "", fmt.Errorf("无法确定平台，请用 /添加管理员 [平台:]用户ID 指定，如 qq:%s", userID)
+		}
+	}
+	if userID == "" {
+		return "", "", errors.New("用户 ID 不能为空")
+	}
+	return platform, userID, nil
 }
 
 // buildBehaviorTree 构建主行为树。

--- a/internal/bot/passes.go
+++ b/internal/bot/passes.go
@@ -122,6 +122,7 @@ func (p *CommandPass) Execute(ctx *conduit.MessageContext) error {
 		MessageID:      messageIDFromCtx(ctx),
 		ConnID:         connIDFromCtx(ctx),
 		CommandReentry: commandReentryFromCtx(ctx),
+		IsSuperUser:    IsSuperUserFromCtx(ctx),
 	})
 
 	// 将回复追加到输出
@@ -215,6 +216,7 @@ func (p *ExecuteCommandPass) Execute(ctx *conduit.MessageContext) error {
 		MessageID:      messageIDFromCtx(ctx),
 		ConnID:         connIDFromCtx(ctx),
 		CommandReentry: commandReentryFromCtx(ctx),
+		IsSuperUser:    IsSuperUserFromCtx(ctx),
 	}
 
 	if err := handlerRaw(cmdCtx); err != nil {

--- a/internal/command/module.go
+++ b/internal/command/module.go
@@ -25,6 +25,9 @@ type Context struct {
 	MessageID string   // 消息 ID
 	ConnID    string   // 来源连接 ID
 
+	// IsSuperUser 当前消息发送者是否为超管（bot 层注入，命令 handler 据此做权限校验）。
+	IsSuperUser bool
+
 	// CommandReentry 标记本次 handler 调用来自插件命令重入（防止插件子树
 	// 未匹配时"命令分支 → 重入 → 命令分支"的无限递归）。
 	CommandReentry bool

--- a/internal/database/admin.go
+++ b/internal/database/admin.go
@@ -1,0 +1,49 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/DaWesen/lanmei-dream/internal/model"
+	"gorm.io/gorm/clause"
+)
+
+// ── 动态管理员数据访问（bot_admin 表）──
+
+// AddAdmin 幂等写入一个动态管理员。
+// 同 (platform, user_id) 已存在时不写入、不报错，返回 existed=true；
+// 新增成功返回 existed=false。
+func (db *DB) AddAdmin(ctx context.Context, platform, userID, createdBy string) (existed bool, err error) {
+	if db.Orm == nil {
+		return false, errors.New("database: orm is nil")
+	}
+	if platform == "" || userID == "" {
+		return false, errors.New("database: admin platform/user_id 不能为空")
+	}
+	stmt := db.Orm.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "platform"}, {Name: "user_id"}},
+		DoNothing: true, // 已存在则静默跳过（幂等）
+	}).Create(&model.BotAdmin{
+		Platform:  platform,
+		UserID:    userID,
+		CreatedBy: createdBy,
+	})
+	if stmt.Error != nil {
+		return false, fmt.Errorf("database: add admin %s:%s: %w", platform, userID, stmt.Error)
+	}
+	// RowsAffected = 0 表示冲突未插入（已存在）
+	return stmt.RowsAffected == 0, nil
+}
+
+// ListAdmins 返回全部动态管理员。
+func (db *DB) ListAdmins(ctx context.Context) ([]model.BotAdmin, error) {
+	if db.Orm == nil {
+		return nil, errors.New("database: orm is nil")
+	}
+	var admins []model.BotAdmin
+	if err := db.Orm.WithContext(ctx).Find(&admins).Error; err != nil {
+		return nil, fmt.Errorf("database: list admins: %w", err)
+	}
+	return admins, nil
+}

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -41,6 +41,7 @@ func (db *DB) Migrate(ctx context.Context, vectorDim int) error {
 		&model.PluginKV{},
 		&model.KnowledgeChunk{},
 		&model.StickerLibrary{},
+		&model.BotAdmin{},
 	); err != nil {
 		return fmt.Errorf("migrate: %w", err)
 	}

--- a/internal/model/admin.go
+++ b/internal/model/admin.go
@@ -1,0 +1,20 @@
+package model
+
+import "time"
+
+// BotAdmin 动态管理员表（bot_admin）。
+//
+// 存放通过命令动态添加的管理员（相对 LANMEI_BOT_SUPER_USERS 静态配置的补充）：
+//   - 静态配置超管：启动时从 env 解析，不进本表；
+//   - 动态管理员：/添加管理员 命令写入本表，重启不丢；
+//   - 判定时静态 + 动态合并：Bot 启动时加载本表并入内存超管集合。
+type BotAdmin struct {
+	ID        uint      `json:"id"         gorm:"primaryKey;autoIncrement;comment:主键"`
+	Platform  string    `json:"platform"   gorm:"uniqueIndex:idx_bot_admin;not null;size:32;comment:平台标识（qq/napcat/wechat/telegram）"`
+	UserID    string    `json:"user_id"    gorm:"uniqueIndex:idx_bot_admin;not null;size:64;comment:平台用户ID"`
+	CreatedBy string    `json:"created_by" gorm:"size:128;comment:添加者（platform:userID）"`
+	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime;comment:创建时间"`
+}
+
+// TableName 指定表名。
+func (BotAdmin) TableName() string { return "bot_admin" }


### PR DESCRIPTION
## feat: 添加动态管理员功能

### 背景
原超管权限仅依赖静态配置 `LANMEI_BOT_SUPER_USERS`，新增/调整管理员必须改环境变量并重启 bot。本 PR 引入**动态管理员**：超管可直接通过命令添加管理员，写入 PostgreSQL 持久化，重启不丢失。

### 改动内容
- **新增 `bot_admin` 表**（`internal/model/admin.go`）：存动态管理员（platform, user_id, created_by），已纳入 AutoMigrate，幂等建表，不影响已有数据
- **数据访问层**（`internal/database/admin.go`）：`AddAdmin`（幂等 upsert，冲突不报错）/ `ListAdmins`
- **Bot 超管集合**（`internal/bot/bot.go`）：
  - 静态配置 + 动态管理员合并为统一内存集合（并发安全）
  - 启动时 `loadDynamicAdmins()` 加载持久化数据（重启不丢）
  - `OnMessage` 注入 `KeyIsSuperUser` 标记
- **管理员命令**（`internal/bot/bot.go`）：
  - 注册 `/添加管理员 [平台:]用户ID`（如 `/添加管理员 qq:123456`）
  - 平台省略时默认取当前消息平台
  - 仅超管可执行；先持久化成功再更新内存，保证一致性
- **权限注入**（`internal/command/module.go`、`internal/bot/passes.go`）：`command.Context` 增加 `IsSuperUser` 字段，`ExecuteCommandPass` 从消息上下文注入，命令 handler 据此做权限校验

### 使用方法
/添加管理员 qq:123456      # 指定平台
/添加管理员 123456          # 默认当前消息平台



### 安全性
- 非超管执行被拦截（仅超管标记注入，动态管理员同样受管）
- DB 不可用时优雅降级（不 panic、不阻断启动，静态超管不受影响）
- 参数化 SQL（GORM）+ 幂等写入

### 兼容性
- 纯增量改动，不动已有表结构和消息路由
- 数据库重启自动建表，无需手动迁移

### 测试
- [ ] `go build ./...`、`go vet ./...` 通过
- [ ] 上线后自测：超管添加管理员 → 新管理员权限生效 → 重启后仍在