### PR TITLE
fix: 兼容非13 WS版本、注册admin帮助命令、L0插件输出过滤

### DIFF
--- a/internal/ai/chat.go
+++ b/internal/ai/chat.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DaWesen/lanmei-dream/internal/ai/tool"
 	"github.com/DaWesen/lanmei-dream/internal/database"
 	kbpkg "github.com/DaWesen/lanmei-dream/internal/kb"
+	modelpkg "github.com/DaWesen/lanmei-dream/internal/model"
 	"go.uber.org/zap"
 )
 
@@ -195,6 +196,19 @@ func (s *ChatService) assembleContext(ctx context.Context, req *llm.ChatRequest)
 			// 跳过空内容历史（如 LLM 空响应误存），否则拼进请求会被 API 以
 			// "missing field content" 拒绝。
 			if strings.TrimSpace(c.Content) == "" {
+				continue
+			}
+			// 插件/工具输出不直接进上下文：插件随机结果（如签到积分文案）不是真实事实，
+			// 原样喂给 LLM 会污染 RAG 上下文（历史教训：插件输出穿透记忆层导致事实污染，
+			// 表现为"要表情却主动签到"）。替换为"用户使用了XX功能"的意图占位，
+			// 保留 role 序列且不含随机结果内容。
+			if c.Role == "assistant" && c.Source == modelpkg.SourcePlugin {
+				tag := c.PluginTag
+				if tag == "" {
+					tag = "插件"
+				}
+				msgs = append(msgs, llm.Message{Role: llm.RoleAssistant,
+					Content: fmt.Sprintf("（用户使用了 %s 功能）", tag)})
 				continue
 			}
 			msgs = append(msgs, llm.Message{Role: llm.Role(c.Role), Content: c.Content})

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -329,13 +329,31 @@ func (b *Bot) loadDynamicAdmins() {
 
 // ── 管理员管理命令 ──
 
-// registerAdminCommands 注册管理员管理命令（/添加管理员）。
+// registerAdminCommands 注册管理员管理命令（/admin 帮助入口 + /添加管理员）。
 func (b *Bot) registerAdminCommands() {
+	// /admin 作为管理员管线（pipeline.admin）入口：IsAdminCommand 匹配 /admin 前缀后
+	// 由 CommandPass 执行，必须注册对应命令，否则报 unknown command: admin。
+	_ = b.cmdSys.Register(command.Command{
+		Name:        "admin",
+		Description: "管理员帮助（仅超管），列出可用管理员命令",
+		Handler:     b.handleAdminHelp,
+	})
 	_ = b.cmdSys.Register(command.Command{
 		Name:        "添加管理员",
 		Description: "添加管理员（仅超管），格式：/添加管理员 [平台:]用户ID，如 /添加管理员 qq:123456",
 		Handler:     b.handleAddAdmin,
 	})
+}
+
+// handleAdminHelp 处理 /admin：列出当前可用的管理员命令。
+func (b *Bot) handleAdminHelp(cmdCtx *command.Context) error {
+	if !cmdCtx.IsSuperUser {
+		cmdCtx.Reply("只有管理员才能查看管理员命令哦~")
+		return nil
+	}
+	cmdCtx.Reply("📋 管理员命令：\n" +
+		"  /添加管理员 [平台:]用户ID — 添加管理员（如 /添加管理员 qq:123456）")
+	return nil
 }
 
 // handleAddAdmin 处理 /添加管理员：

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -54,6 +54,21 @@ func NewServer(cfg *ListenConfig, logger *zap.Logger, handler EventHandler) *Ser
 	s.upgrader = gws.NewUpgrader(s, &gws.ServerOption{
 		ParallelEnabled: true,
 		Recovery:        gws.Recovery,
+		// 兼容非 13 的 WS 版本：gws 只接受 Sec-WebSocket-Version: 13（RFC6455），
+		// 部分 OneBot 客户端（如新版 llonebot）握手时发送其他版本。
+		// 握手后的帧格式相同（RFC6455 基于 hybi-10），改写版本头放行不影响后续解析。
+		// Authorize 在 gws 的版本检查之前执行（见 gws.upgrader.doUpgradeFromConn）。
+		Authorize: func(r *http.Request, _ gws.SessionStorage) bool {
+			ver := r.Header.Get("Sec-WebSocket-Version")
+			if ver != "" && ver != "13" {
+				logger.Info("gateway: WS 版本兼容",
+					zap.String("version", ver),
+					zap.String("remote", r.RemoteAddr),
+				)
+			}
+			r.Header.Set("Sec-WebSocket-Version", "13")
+			return true
+		},
 	})
 	return s
 }


### PR DESCRIPTION
## fix: 兼容非13 WS版本、注册admin帮助命令、L0插件输出过滤

### 改动内容

**1. gateway：兼容非 13 的 WebSocket 版本握手**
- 文件：`internal/gateway/server.go`
- 新版 llonebot 等 OneBot 客户端握手时不发送 `Sec-WebSocket-Version: 13`（RFC6455），被 gws 拒绝（`websocket version not supported`），表现为"小号连不上、大号正常"
- 通过 gws `Authorize` hook（在版本检查之前执行）将版本头改写为 13 后放行，握手后的帧格式相同，不影响后续解析
- 记录实际收到的版本号日志，便于排查

**2. bot：注册 /admin 帮助命令**
- 文件：`internal/bot/bot.go`
- `/admin` 前缀消息被路由到 `pipeline.admin`，但命令系统未注册 `admin` 命令，导致 `unknown command: admin` 报错
- 注册 `admin` 帮助命令：超管输入 `/admin` 列出可用管理员命令；非超管被拦截

**3. ai：L0 历史过滤插件/工具输出**
- 文件：`internal/ai/chat.go`
- 根因：LOD 的 L0 原始历史原样加载 `SourcePlugin` 的 assistant 消息（如签到结果"你和学姐一起三角洲，获得12积分"），直接喂给 LLM，污染 RAG 上下文，表现为"要表情却主动签到"
- 修复：组装 L0 时，将插件来源的 assistant 消息替换为意图占位 `（用户使用了 XXX 功能）`，保留 role 序列但剔除随机结果内容

### 背景
本提交为 `feat/dynamic-admin` 分支上"添加动态管理员"（已提交 `8cb829c`）之后的三处联动修复，均在联调中暴露并修复。

### 测试
- [x] `go build ./...`、`go vet ./...` 通过
- [x] 小号 llonebot 可正常连接（`gateway: 新连接`）
- [x] `/admin` 返回管理员命令列表
- [ ] 聊天"发个表情"不再被历史里的签到结果带偏