### PR TITLE
feat: 接入火山方舟 doubao-embedding-vision 多模态向量化

### DIFF
--- a/cmd/lanmei/main.go
+++ b/cmd/lanmei/main.go
@@ -106,17 +106,32 @@ func main() {
 
 	// ── Embedder 客户端 ──
 	if cfg.AI.EmbeddingAPIKey != "" {
-		einoEmb, err := embedding.NewEinoEmbedder(ctx, &embedding.EinoOptions{
+		embOpts := &embedding.EinoOptions{
 			BaseURL:   cfg.AI.EmbeddingBaseURL,
 			APIKey:    cfg.AI.EmbeddingAPIKey,
 			Model:     cfg.AI.EmbeddingModel,
 			Dimension: cfg.AI.EmbeddingDim,
-		})
-		if err != nil {
-			logger.Fatal("Embedder 初始化失败", zap.Error(err))
 		}
-		embedder = einoEmb
-		logger.Info("Embedder 就绪", zap.String("base_url", cfg.AI.EmbeddingBaseURL), zap.String("model", cfg.AI.EmbeddingModel), zap.Int("dim", cfg.AI.EmbeddingDim))
+		// 火山方舟 doubao-embedding-vision 系列：标准 OpenAI /embeddings 端点不支持其
+		// 多模态格式，走专用实现（POST /embeddings/multimodal，input=[{type,text}]）。
+		if strings.Contains(cfg.AI.EmbeddingBaseURL, "volces.com") || strings.HasPrefix(cfg.AI.EmbeddingModel, "doubao-embedding") {
+			volcEmb, err := embedding.NewVolcEmbedder(embOpts)
+			if err != nil {
+				logger.Fatal("Embedder 初始化失败", zap.Error(err))
+			}
+			embedder = volcEmb
+			logger.Info("VolcEngine Embedder 就绪",
+				zap.String("base_url", cfg.AI.EmbeddingBaseURL),
+				zap.String("model", cfg.AI.EmbeddingModel),
+				zap.Int("dim", cfg.AI.EmbeddingDim))
+		} else {
+			einoEmb, err := embedding.NewEinoEmbedder(ctx, embOpts)
+			if err != nil {
+				logger.Fatal("Embedder 初始化失败", zap.Error(err))
+			}
+			embedder = einoEmb
+			logger.Info("Embedder 就绪", zap.String("base_url", cfg.AI.EmbeddingBaseURL), zap.String("model", cfg.AI.EmbeddingModel), zap.Int("dim", cfg.AI.EmbeddingDim))
+		}
 	} else {
 		logger.Warn("Embedding API Key 未配置，RAG 检索不可用")
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,8 @@ services:
       - ./prompts:/app/prompts:ro
       # Skill 系统（只读）
       - ./skills:/app/skills:ro
+      # 知识库目录（只读）：Markdown / CSV 文件自动摄入
+      - ./docs:/app/docs:ro
     ports:
       - "${LANMEI_PORT:-8080}:8080"
     depends_on:

--- a/internal/ai/embedding/ark.go
+++ b/internal/ai/embedding/ark.go
@@ -1,0 +1,140 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// VolcEmbedder 火山方舟多模态 Embedding 客户端。
+//
+// 适配 doubao-embedding-vision 系列模型：请求 POST {base}/embeddings/multimodal，
+// 输入格式 input=[{"type":"text","text":"..."}]，响应为 OpenAI 兼容结构
+// {"data":[{"embedding":[...]}]}。
+type VolcEmbedder struct {
+	baseURL   string
+	apiKey    string
+	model     string
+	dimension int
+	client    *http.Client
+}
+
+// NewVolcEmbedder 创建火山方舟多模态 Embedding 客户端。
+// opts.BaseURL 为方舟 API 根地址（如 https://ark.cn-beijing.volces.com/api/v3），
+// 客户端自动追加 /embeddings/multimodal 路径。
+func NewVolcEmbedder(opts *EinoOptions) (*VolcEmbedder, error) {
+	if opts.APIKey == "" {
+		return nil, fmt.Errorf("embedding: 火山方舟需要 api_key")
+	}
+	if opts.Model == "" {
+		return nil, fmt.Errorf("embedding: 火山方舟需要 model")
+	}
+	return &VolcEmbedder{
+		baseURL:   strings.TrimRight(opts.BaseURL, "/"),
+		apiKey:    opts.APIKey,
+		model:     opts.Model,
+		dimension: opts.Dimension,
+		client:    &http.Client{Timeout: 60 * time.Second},
+	}, nil
+}
+
+// Dimension 实现 Embedder 接口。
+func (e *VolcEmbedder) Dimension() int { return e.dimension }
+
+// Embed 实现 Embedder 接口。
+func (e *VolcEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	vecs, err := e.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) == 0 {
+		return nil, fmt.Errorf("embedding: 火山方舟空响应")
+	}
+	return vecs[0], nil
+}
+
+// EmbedBatch 实现 Embedder 接口。
+// 实测火山方舟多模态接口每条请求仅返回一个向量（多 input 也只回第一条），
+// 且响应中 data 为对象 {embedding:[...]}（非 OpenAI 标准数组），故逐条调用并解析对象。
+func (e *VolcEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	vecs := make([][]float32, 0, len(texts))
+	for _, t := range texts {
+		v, err := e.embedOne(ctx, t)
+		if err != nil {
+			return nil, err
+		}
+		vecs = append(vecs, v)
+	}
+	return vecs, nil
+}
+
+// embedOne 请求单条文本的向量。
+func (e *VolcEmbedder) embedOne(ctx context.Context, text string) ([]float32, error) {
+	// 多模态格式：input 为 {type,text} 对象数组
+	payload := map[string]any{
+		"model":      e.model,
+		"input":      []map[string]string{{"type": "text", "text": text}},
+		"dimensions": e.dimension,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("embedding: 序列化请求: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		e.baseURL+"/embeddings/multimodal", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("embedding: 构造请求: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+e.apiKey)
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("embedding: 火山方舟请求失败: %w", err)
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	if err != nil {
+		return nil, fmt.Errorf("embedding: 读取响应: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("embedding: 火山方舟错误 status=%d body=%s",
+			resp.StatusCode, truncateString(string(data), 300))
+	}
+
+	// 响应结构：{"data":{"embedding":[...],"index":0},...}
+	var out struct {
+		Data struct {
+			Embedding []float64 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("embedding: 解析响应: %w", err)
+	}
+	if len(out.Data.Embedding) == 0 {
+		return nil, fmt.Errorf("embedding: 响应缺少 embedding 向量")
+	}
+
+	v := make([]float32, len(out.Data.Embedding))
+	for j, f := range out.Data.Embedding {
+		v[j] = float32(f)
+	}
+	return v, nil
+}
+
+// truncateString 截断错误响应体，避免日志刷屏。
+func truncateString(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}


### PR DESCRIPTION
- 新增 VolcEmbedder（POST /embeddings/multimodal，逐条调用，解析 data 对象）- main.go 按 BaseURL/模型名自动选择方舟专用实现- docker-compose 挂载 ./docs 到容器，知识库 CSV 可摄入