### PR TITLE
Fix:intent timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ LANMEI_BOT_NICKNAME=蓝妹
 # 超级用户，格式：platform:userID,逗号分隔
 # 示例：qq:123456,wechat:wxid_xxx,napcat:654321
 LANMEI_BOT_SUPER_USERS=
+# 意图分析 LLM 独立超时（秒）：意图分析只是路由前置步骤，
+# LLM 故障时快速降级，避免吃满消息预算（默认 20s）触发"迷糊"兜底回复
+LANMEI_BOT_INTENT_TIMEOUT_SECONDS=8
 
 # ── LLM（OpenAI 兼容 API，支持 DeepSeek/Qwen/Moonshot/GLM 等）──
 # 填入 API Key 后角色扮演和意图分析自动启用

--- a/internal/ai/intent/intent.go
+++ b/internal/ai/intent/intent.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/DaWesen/lanmei-dream/internal/ai/llm"
 )
@@ -88,8 +89,9 @@ type JudgeContext struct {
 //   - Analyzer 不执行命令或工具，只负责分类——执行由上层路由逻辑完成
 type Analyzer struct {
 	llmClient llm.LLMClient
-	commands  []CommandDef // 可用命令列表（注入到 prompt 中供 LLM 匹配）
-	tools     []ToolDef    // 可用工具列表（注入到 prompt 中供 LLM 匹配）
+	commands  []CommandDef  // 可用命令列表（注入到 prompt 中供 LLM 匹配）
+	tools     []ToolDef     // 可用工具列表（注入到 prompt 中供 LLM 匹配）
+	timeout   time.Duration // 单次 LLM 调用超时（<=0 表示不设独立超时，沿用父上下文）
 }
 
 // CommandDef 描述一个可用命令，用于构建意图分析 prompt。
@@ -112,11 +114,15 @@ type ToolDef struct {
 //   - llmClient: LLM 客户端，为 nil 时 Analyze 降级返回 IntentChat
 //   - commands: 可用命令定义列表
 //   - tools: 可用工具定义列表
-func NewAnalyzer(llmClient llm.LLMClient, commands []CommandDef, tools []ToolDef) *Analyzer {
+//   - timeout: 单次 LLM 调用超时（<=0 表示不设独立超时，沿用父上下文）。
+//     意图分析只是路由前置步骤，不应吃满整条消息的处理预算；
+//     给独立短超时可在 LLM 故障时快速降级，避免后续对话管线失去剩余时间。
+func NewAnalyzer(llmClient llm.LLMClient, commands []CommandDef, tools []ToolDef, timeout time.Duration) *Analyzer {
 	return &Analyzer{
 		llmClient: llmClient,
 		commands:  commands,
 		tools:     tools,
+		timeout:   timeout,
 	}
 }
 
@@ -164,7 +170,16 @@ func (a *Analyzer) Analyze(ctx context.Context, userMsg string, judgeCtx *JudgeC
 		user = formatJudgeUser(userMsg, judgeCtx.Recent)
 	}
 
-	resp, err := a.llmClient.Chat(ctx, &llm.ChatRequest{
+	// 独立短超时：意图分析不应吃满消息处理预算（父 ctx 可能为消息级 20s 超时）。
+	// 超时后快速失败并降级为 chat，保证后续对话管线仍有剩余时间可用。
+	llmCtx := ctx
+	cancel := func() {}
+	if a.timeout > 0 {
+		llmCtx, cancel = context.WithTimeout(ctx, a.timeout)
+		defer cancel()
+	}
+
+	resp, err := a.llmClient.Chat(llmCtx, &llm.ChatRequest{
 		Messages: []llm.Message{
 			{Role: llm.RoleSystem, Content: prompt},
 			{Role: llm.RoleUser, Content: user},

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -259,9 +259,12 @@ func New(cfg *config.BotConfig, cmdSys *command.System, chatSvc *ai.ChatService,
 	)
 
 	// ── 构建意图分析器（LLM 不可用时自动降级为 IntentChat）──
+	// intentTimeout：意图分析独立短超时（默认 8s），LLM 故障时快速降级，
+	// 避免吃满整条消息的 20s 预算触发"迷糊"兜底回复。
+	intentTimeout := time.Duration(cfg.IntentTimeoutSeconds) * time.Second
 	cmdDefs := BuildIntentCommands(cmdSys)
 	toolDefs := BuildIntentTools(toolReg)
-	analyzer := intent.NewAnalyzer(llmClient, cmdDefs, toolDefs)
+	analyzer := intent.NewAnalyzer(llmClient, cmdDefs, toolDefs, intentTimeout)
 
 	// ── 注册 Pass 与管线 ──
 	// 核心管线全部以"动态管线"（PassID 引用）注册：

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,8 @@ type PluginBuiltinsConfig struct {
 	Music bool `mapstructure:"music"`
 	// Sticker 自定义表情库插件
 	Sticker bool `mapstructure:"sticker"`
+	// TurtleSoup 海龟汤文字游戏插件
+	TurtleSoup bool `mapstructure:"turtle_soup"`
 }
 
 // DatabaseConfig 数据库配置
@@ -137,6 +139,11 @@ type BotConfig struct {
 	Stream     StreamConfig  `mapstructure:"stream"`
 	Media      MediaConfig   `mapstructure:"media"`
 	Topic      TopicConfig   `mapstructure:"topic"`
+	// IntentTimeoutSeconds 意图分析 LLM 调用的独立超时（秒）。
+	// 意图分析只是消息路由前置步骤，不应吃满整条消息的处理预算；
+	// LLM 故障时快速降级，避免后续对话管线失去剩余时间、触发"迷糊"兜底。
+	// 0 表示不设独立超时（沿用消息级超时，默认 20s）。
+	IntentTimeoutSeconds int `mapstructure:"intent_timeout_seconds"`
 }
 
 // MediaConfig 多媒体处理配置（RustFS 对象存储 + 视觉理解）

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -55,6 +55,7 @@ func Init() (*Config, error) {
 		"LANMEI_BOT_SUPER_USERS":             "bot.super_users",
 		"LANMEI_BOT_GATEWAY_LISTEN_ADDR":     "bot.gateway.listen_addr",
 		"LANMEI_BOT_GATEWAY_ACCESS_TOKEN":    "bot.gateway.access_token",
+		"LANMEI_BOT_INTENT_TIMEOUT_SECONDS":  "bot.intent_timeout_seconds",
 		"LANMEI_AI_LLM_API_KEY":              "ai.llm_api_key",
 		"LANMEI_AI_LLM_BASE_URL":             "ai.llm_base_url",
 		"LANMEI_AI_LLM_MODEL":                "ai.llm_model",
@@ -129,6 +130,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("bot.nickname", "蓝妹")
 	v.SetDefault("bot.super_users", "")
 	v.SetDefault("bot.gateway.listen_addr", "0.0.0.0:8080")
+	v.SetDefault("bot.intent_timeout_seconds", 8)    // 意图分析独立超时 8s，LLM 故障时快速降级，避免吃满消息预算
 	v.SetDefault("bot.stream.typing_speed_ms", 150)  // 150ms/字，模拟打字速度
 	v.SetDefault("bot.stream.min_interval_ms", 1000) // 最小 1 秒
 	v.SetDefault("bot.stream.max_interval_ms", 5000) // 最大 5 秒（长消息段间隔上限，避免过久等待）
@@ -147,6 +149,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("plugin.builtins.welcome", true)
 	v.SetDefault("plugin.builtins.poke", true)
 	v.SetDefault("plugin.builtins.three_g", true)
+	v.SetDefault("plugin.builtins.turtle_soup", true)
 
 	// 群聊 topic 系统默认值
 	v.SetDefault("bot.topic.enabled", true)


### PR DESCRIPTION

根因链路：

1. 引擎对每条消息设 20s 总超时（`conduit.WithTimeout(20*time.Second)`），而意图分析的 LLM 调用**直接使用消息级 ctx、无独立超时**；
2. LLM 卡死时 `Analyze` 耗满 20s 才返回 `context deadline exceeded`，此时消息 ctx 已过期；
3. 引擎在进入下一管线前检查 `ctx.Ctx.Err()` 命中 `DeadlineExceeded`（`conduit engine.go`），随即执行 fallback 管线；
4. `FallbackPass` 输出「蓝妹现在有点迷糊，稍等一下...」——即使该消息本应按"未提及"静默存档。

即：**意图分析这一个前置步骤就吃光了整条消息的处理预算**，导致降级逻辑（按未提及处理 → 静默）完全失效。

## 修复逻辑

给意图分析 LLM 调用增加**独立短超时**（默认 8s，可配置）：

- `Analyzer` 新增可配置超时字段，`Analyze` 内用 `context.WithTimeout` 包裹 LLM 调用（构造函数注入，`intent` 包不依赖 config 包）；
- 超时后快速失败并降级为 `IntentChat`，消息仍有剩余预算走后续管线：
  - 非 @ 群消息 → 按未提及静默存档，不再回复「迷糊」；
  - @ 消息 → 对话管线仍可用剩余时间重试/处理；
- 配置项 `bot.intent_timeout_seconds`（环境变量 `LANMEI_BOT_INTENT_TIMEOUT_SECONDS`，默认 8，0 表示不设独立超时）。

## 改动清单

| 文件 | 改动 |
|---|---|
| `internal/ai/intent/intent.go` | `Analyzer` 增加 `timeout` 字段；`NewAnalyzer` 增加参数；`Analyze` 包裹 LLM 调用 |
| `internal/bot/bot.go` | `NewAnalyzer` 传入 `cfg.IntentTimeoutSeconds` |
| `internal/config/config.go` | `BotConfig` 新增 `IntentTimeoutSeconds` |
| `internal/config/init.go` | 默认值 8s + 环境变量映射 |
| `.env.example` | 新增 `LANMEI_BOT_INTENT_TIMEOUT_SECONDS=8` |



次要隐患：`topic.embedMessage` 的 embedding 调用同样沿用消息 ctx，embedding 服务慢时可能重复该问题（可按相同模式加独立超时，本次未改）。

## 验证

- `go build ./...` 通过
- `go test ./internal/bot/...` 通过