### PR TITLE
fix: 海龟汤出题/判定 LLM 调用增加独立超时，LLM 慢时快速降级避免耗尽消息预算

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ LANMEI_BOT_SUPER_USERS=
 # 意图分析 LLM 独立超时（秒）：意图分析只是路由前置步骤，
 # LLM 故障时快速降级，避免吃满消息预算（默认 20s）触发"迷糊"兜底回复
 LANMEI_BOT_INTENT_TIMEOUT_SECONDS=8
+# 海龟汤出题/判定 LLM 独立超时（秒）：LLM 慢时快速降级回"汤煮糊了"，不耗尽消息预算
+LANMEI_BOT_TURTLE_SOUP_TIMEOUT_SECONDS=15
 
 # ── LLM（OpenAI 兼容 API，支持 DeepSeek/Qwen/Moonshot/GLM 等）──
 # 填入 API Key 后角色扮演和意图分析自动启用

--- a/cmd/lanmei/main.go
+++ b/cmd/lanmei/main.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/DaWesen/lanmei-dream/internal/ai"
 	"github.com/DaWesen/lanmei-dream/internal/ai/embedding"
@@ -285,6 +286,8 @@ func main() {
 	bizReg.SetMusicSendMode(cfg.Plugin.MusicSendMode)
 	bizReg.SetObjectStore(inf.ObjectStore)
 	bizReg.SetLLMClient(llmClient)
+	// 海龟汤出题/判定 LLM 独立超时（默认 15s）：LLM 慢时快速降级回"汤煮糊了"，不耗尽消息预算
+	bizReg.SetTurtleSoupTimeout(time.Duration(cfg.Bot.TurtleSoupTimeoutSeconds) * time.Second)
 	if err := bizReg.RegisterBuiltins(); err != nil {
 		logger.Fatal("内置业务插件注册失败", zap.Error(err))
 	}

--- a/internal/bizplugin/registry.go
+++ b/internal/bizplugin/registry.go
@@ -2,6 +2,7 @@ package bizplugin
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/DaWesen/lanmei-dream/internal/ai/llm"
 	"github.com/DaWesen/lanmei-dream/internal/config"
@@ -25,13 +26,14 @@ import (
 //   - 插件私有业务数据通过受限 KV 存储（PluginContext.KV，PostgreSQL 持久化）读写，
 //     内置插件不直接持有裸数据库。
 type BusinessRegistry struct {
-	cfg           *config.PluginBuiltinsConfig // 内置插件开关配置
-	registry      *pluginpkg.Registry          // 插件注册表
-	ncmURL        string                       // 网易云音乐 API 地址（点歌插件使用）
-	musicSendMode string                       // 点歌发送方式：auto/card/link
-	store         *media.ObjectStore           // RustFS 对象存储（表情库插件使用，未配置时为 nil）
-	llmClient     llm.LLMClient                // LLM 客户端（海龟汤插件出题/判定使用，未配置时为 nil）
-	logger        *zap.Logger
+	cfg               *config.PluginBuiltinsConfig // 内置插件开关配置
+	registry          *pluginpkg.Registry          // 插件注册表
+	ncmURL            string                       // 网易云音乐 API 地址（点歌插件使用）
+	musicSendMode     string                       // 点歌发送方式：auto/card/link
+	store             *media.ObjectStore           // RustFS 对象存储（表情库插件使用，未配置时为 nil）
+	llmClient         llm.LLMClient                // LLM 客户端（海龟汤插件出题/判定使用，未配置时为 nil）
+	turtleSoupTimeout time.Duration                // 海龟汤出题/判定 LLM 调用独立超时（<=0 不限制）
+	logger            *zap.Logger
 }
 
 // NewBusinessRegistry 创建内置业务插件注册表。
@@ -61,6 +63,11 @@ func (r *BusinessRegistry) SetObjectStore(store *media.ObjectStore) {
 // SetLLMClient 设置 LLM 客户端（海龟汤插件依赖；未配置时该插件命令提示不可用）。
 func (r *BusinessRegistry) SetLLMClient(client llm.LLMClient) {
 	r.llmClient = client
+}
+
+// SetTurtleSoupTimeout 设置海龟汤出题/判定 LLM 调用的独立超时（<=0 不限制）。
+func (r *BusinessRegistry) SetTurtleSoupTimeout(timeout time.Duration) {
+	r.turtleSoupTimeout = timeout
 }
 
 // RegisterBuiltins 按配置注册所有内置业务插件。
@@ -158,7 +165,7 @@ func (r *BusinessRegistry) RegisterBuiltins() error {
 	}
 
 	// ── 海龟汤文字游戏插件 ──
-	if err := register(builtins.TurtleSoup, "turtle_soup", NewTurtleSoupPlugin(r.llmClient, logger)); err != nil {
+	if err := register(builtins.TurtleSoup, "turtle_soup", NewTurtleSoupPlugin(r.llmClient, logger, r.turtleSoupTimeout)); err != nil {
 		return err
 	}
 

--- a/internal/bizplugin/turtle_soup.go
+++ b/internal/bizplugin/turtle_soup.go
@@ -45,12 +45,15 @@ type TurtleSoupPlugin struct {
 	llmClient llm.LLMClient
 	kv        *database.PluginKVStore
 	logger    *zap.Logger
+	// timeout 出题/判定 LLM 调用的独立超时（<=0 不设独立超时，沿用消息级预算）。
+	// 命令管线受消息级超时约束，给独立上限可避免 LLM 慢时耗尽预算触发"迷糊"兜底。
+	timeout time.Duration
 }
 
 // NewTurtleSoupPlugin 创建海龟汤插件。llmClient 为 nil 时出题/判定不可用，
-// 命令会提示配置缺失。
-func NewTurtleSoupPlugin(llmClient llm.LLMClient, logger *zap.Logger) *TurtleSoupPlugin {
-	return &TurtleSoupPlugin{llmClient: llmClient, logger: logger}
+// 命令会提示配置缺失；timeout 为出题/判定 LLM 调用的独立超时（<=0 不限制）。
+func NewTurtleSoupPlugin(llmClient llm.LLMClient, logger *zap.Logger, timeout time.Duration) *TurtleSoupPlugin {
+	return &TurtleSoupPlugin{llmClient: llmClient, logger: logger, timeout: timeout}
 }
 
 // Info 返回海龟汤插件元信息。
@@ -75,7 +78,7 @@ func (p *TurtleSoupPlugin) OnInit(ctx *pluginpkg.PluginContext) error {
 	p.kv = ctx.KV
 
 	passID := pluginpkg.PassID("turtle_soup", "main")
-	pass := &turtleSoupPass{llmClient: p.llmClient, kv: p.kv, logger: p.logger}
+	pass := &turtleSoupPass{llmClient: p.llmClient, kv: p.kv, logger: p.logger, timeout: p.timeout}
 	if err := ctx.Engine.RegisterPass(passID, pass); err != nil {
 		return fmt.Errorf("register turtle_soup pass: %w", err)
 	}
@@ -243,11 +246,19 @@ type turtleGuessResult struct {
 }
 
 // chatJSON 调用 LLM 并解析 JSON 响应（容错：剥离 markdown 代码块围栏）。
-func chatJSON(ctx context.Context, client llm.LLMClient, system, user string, out any) error {
+// timeout > 0 时为 LLM 调用设置独立超时：LLM 慢/故障时快速降级返回，
+// 避免耗尽消息级预算（20s）触发"迷糊"兜底；<=0 则沿用传入 ctx。
+func chatJSON(ctx context.Context, client llm.LLMClient, system, user string, out any, timeout time.Duration) error {
 	if client == nil {
 		return fmt.Errorf("LLM 不可用")
 	}
-	resp, err := client.Chat(ctx, &llm.ChatRequest{
+	llmCtx := ctx
+	cancel := func() {}
+	if timeout > 0 {
+		llmCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	resp, err := client.Chat(llmCtx, &llm.ChatRequest{
 		Messages: []llm.Message{
 			{Role: llm.RoleSystem, Content: system},
 			{Role: llm.RoleUser, Content: user},
@@ -265,8 +276,8 @@ func chatJSON(ctx context.Context, client llm.LLMClient, system, user string, ou
 	return json.Unmarshal([]byte(raw), out)
 }
 
-// generateSoup 让 LLM 生成一局海龟汤。
-func generateSoup(ctx context.Context, client llm.LLMClient) (*turtleGame, error) {
+// generateSoup 让 LLM 生成一局海龟汤。timeout 为 LLM 调用独立超时（<=0 不限制）。
+func generateSoup(ctx context.Context, client llm.LLMClient, timeout time.Duration) (*turtleGame, error) {
 	const system = `你是一个海龟汤（情境推理谜题）出题人。请生成一个经典风格的海龟汤谜题：
 - 汤面（soup_face）：简短、离奇、让人困惑的情境描述（1-3 句话），只陈述现象，不含任何解释
 - 汤底（soup_base）：完整合理的真相（1-3 句话），能自洽解释汤面
@@ -274,7 +285,7 @@ func generateSoup(ctx context.Context, client llm.LLMClient) (*turtleGame, error
 要求：情境不得涉及血腥、暴力、色情、违法或不适内容，适合校园群聊；谜题要有趣且逻辑自洽。
 仅输出 JSON，不要其他内容：{"soup_face":"...","soup_base":"...","hints":"..."}`
 	resp := &turtleGeneration{}
-	if err := chatJSON(ctx, client, system, "请生成一局海龟汤。", resp); err != nil {
+	if err := chatJSON(ctx, client, system, "请生成一局海龟汤。", resp, timeout); err != nil {
 		return nil, err
 	}
 	if strings.TrimSpace(resp.SoupFace) == "" || strings.TrimSpace(resp.SoupBase) == "" {
@@ -288,8 +299,8 @@ func generateSoup(ctx context.Context, client llm.LLMClient) (*turtleGame, error
 	}, nil
 }
 
-// judgeQuestion 让 LLM 判定提问的答案是 是/否/无关。
-func judgeQuestion(ctx context.Context, client llm.LLMClient, g *turtleGame, question string) (string, error) {
+// judgeQuestion 让 LLM 判定提问的答案是 是/否/无关。timeout 为 LLM 调用独立超时。
+func judgeQuestion(ctx context.Context, client llm.LLMClient, g *turtleGame, question string, timeout time.Duration) (string, error) {
 	var sb strings.Builder
 	sb.WriteString("你正在主持一个海龟汤（情境推理）游戏，只回答 是/否/无关。\n\n")
 	sb.WriteString("汤面：" + g.SoupFace + "\n")
@@ -309,7 +320,7 @@ func judgeQuestion(ctx context.Context, client llm.LLMClient, g *turtleGame, que
 可附一句不超过 15 字的补充提示（comment），不要直接透露汤底。
 仅输出 JSON：{"answer":"是","comment":"..."}`)
 	resp := &turtleJudgement{}
-	if err := chatJSON(ctx, client, "你是海龟汤主持人，回答必须严格基于汤底事实。", sb.String(), resp); err != nil {
+	if err := chatJSON(ctx, client, "你是海龟汤主持人，回答必须严格基于汤底事实。", sb.String(), resp, timeout); err != nil {
 		return "", err
 	}
 	switch resp.Answer {
@@ -322,12 +333,12 @@ func judgeQuestion(ctx context.Context, client llm.LLMClient, g *turtleGame, que
 	return strings.TrimSpace(resp.Answer + " " + resp.Comment), nil
 }
 
-// judgeGuess 让 LLM 判定玩家的猜测是否命中汤底。
-func judgeGuess(ctx context.Context, client llm.LLMClient, g *turtleGame, guess string) (bool, string, error) {
+// judgeGuess 让 LLM 判定玩家的猜测是否命中汤底。timeout 为 LLM 调用独立超时。
+func judgeGuess(ctx context.Context, client llm.LLMClient, g *turtleGame, guess string, timeout time.Duration) (bool, string, error) {
 	system := "你是海龟汤主持人，判断玩家的猜测是否命中了汤底的核心真相（抓住关键事实即可，不必逐字一致）。"
 	user := fmt.Sprintf("汤底：%s\n\n玩家猜测：%s\n\n仅输出 JSON：{\"correct\":true,\"comment\":\"...\"}", g.SoupBase, guess)
 	resp := &turtleGuessResult{}
-	if err := chatJSON(ctx, client, system, user, resp); err != nil {
+	if err := chatJSON(ctx, client, system, user, resp, timeout); err != nil {
 		return false, "", err
 	}
 	return resp.Correct, strings.TrimSpace(resp.Comment), nil
@@ -342,6 +353,7 @@ type turtleSoupPass struct {
 	llmClient llm.LLMClient
 	kv        *database.PluginKVStore
 	logger    *zap.Logger
+	timeout   time.Duration // 出题/判定 LLM 调用独立超时（<=0 不限制）
 }
 
 func (pass *turtleSoupPass) Execute(ctx *conduit.MessageContext) error {
@@ -380,7 +392,7 @@ func (pass *turtleSoupPass) open(ctx *conduit.MessageContext) error {
 	}
 
 	pass.reply(ctx, "正在煮汤，稍等一下…")
-	game, err := generateSoup(ctx.Ctx, pass.llmClient)
+	game, err := generateSoup(ctx.Ctx, pass.llmClient, pass.timeout)
 	if err != nil {
 		pass.logger.Warn("turtle_soup: 出题失败", zap.Error(err))
 		pass.reply(ctx, "汤煮糊了，稍后再试一次吧 (￣ω￣;)")
@@ -414,7 +426,7 @@ func (pass *turtleSoupPass) ask(ctx *conduit.MessageContext, question string) er
 		return nil
 	}
 
-	answer, err := judgeQuestion(ctx.Ctx, pass.llmClient, game, question)
+	answer, err := judgeQuestion(ctx.Ctx, pass.llmClient, game, question, pass.timeout)
 	if err != nil {
 		pass.logger.Warn("turtle_soup: 判定失败", zap.Error(err))
 		pass.reply(ctx, "蓝妹走神了，再问一次吧 (￣ω￣;)")
@@ -444,7 +456,7 @@ func (pass *turtleSoupPass) guess(ctx *conduit.MessageContext, guess string) err
 		return nil
 	}
 
-	correct, comment, err := judgeGuess(ctx.Ctx, pass.llmClient, game, guess)
+	correct, comment, err := judgeGuess(ctx.Ctx, pass.llmClient, game, guess, pass.timeout)
 	if err != nil {
 		pass.logger.Warn("turtle_soup: 猜答案判定失败", zap.Error(err))
 		pass.reply(ctx, "蓝妹走神了，再猜一次吧 (￣ω￣;)")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -144,6 +144,10 @@ type BotConfig struct {
 	// LLM 故障时快速降级，避免后续对话管线失去剩余时间、触发"迷糊"兜底。
 	// 0 表示不设独立超时（沿用消息级超时，默认 20s）。
 	IntentTimeoutSeconds int `mapstructure:"intent_timeout_seconds"`
+	// TurtleSoupTimeoutSeconds 海龟汤插件出题/判定的 LLM 独立超时（秒）。
+	// 命令管线同样受消息级超时约束，LLM 慢时给独立上限可快速降级
+	//（回"汤煮糊了"），避免耗尽预算触发"迷糊"兜底。0 表示不设独立超时。
+	TurtleSoupTimeoutSeconds int `mapstructure:"turtle_soup_timeout_seconds"`
 }
 
 // MediaConfig 多媒体处理配置（RustFS 对象存储 + 视觉理解）

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -49,27 +49,28 @@ func Init() (*Config, error) {
 	//（如 llm_api_key, super_users），这个映射是 Viper 内部 (cfgKey → envVar)
 	// 的单向变换，不可逆。
 	envToCfg := map[string]string{
-		"LANMEI_DATABASE_URL":                "database.url",
-		"LANMEI_REDIS_ADDR":                  "redis.addr",
-		"LANMEI_BOT_NICKNAME":                "bot.nickname",
-		"LANMEI_BOT_SUPER_USERS":             "bot.super_users",
-		"LANMEI_BOT_GATEWAY_LISTEN_ADDR":     "bot.gateway.listen_addr",
-		"LANMEI_BOT_GATEWAY_ACCESS_TOKEN":    "bot.gateway.access_token",
-		"LANMEI_BOT_INTENT_TIMEOUT_SECONDS":  "bot.intent_timeout_seconds",
-		"LANMEI_AI_LLM_API_KEY":              "ai.llm_api_key",
-		"LANMEI_AI_LLM_BASE_URL":             "ai.llm_base_url",
-		"LANMEI_AI_LLM_MODEL":                "ai.llm_model",
-		"LANMEI_AI_LLM_MAX_TOKENS":           "ai.llm_max_tokens",
-		"LANMEI_AI_LLM_TEMPERATURE":          "ai.llm_temperature",
-		"LANMEI_AI_EMBEDDING_API_KEY":        "ai.embedding_api_key",
-		"LANMEI_AI_EMBEDDING_BASE_URL":       "ai.embedding_base_url",
-		"LANMEI_AI_EMBEDDING_MODEL":          "ai.embedding_model",
-		"LANMEI_AI_EMBEDDING_DIM":            "ai.embedding_dim",
-		"LANMEI_PLUGIN_ROOT_DIR":             "plugin.root_dir",
-		"LANMEI_PLUGIN_NCM_URL":              "plugin.ncm_url",
-		"LANMEI_PLUGIN_MUSIC_SEND_MODE":      "plugin.music_send_mode",
-		"LANMEI_KNOWLEDGE_ENABLED":           "knowledge.enabled",
-		"LANMEI_KNOWLEDGE_AUTO_RECALL_LIMIT": "knowledge.auto_recall_limit",
+		"LANMEI_DATABASE_URL":                    "database.url",
+		"LANMEI_REDIS_ADDR":                      "redis.addr",
+		"LANMEI_BOT_NICKNAME":                    "bot.nickname",
+		"LANMEI_BOT_SUPER_USERS":                 "bot.super_users",
+		"LANMEI_BOT_GATEWAY_LISTEN_ADDR":         "bot.gateway.listen_addr",
+		"LANMEI_BOT_GATEWAY_ACCESS_TOKEN":        "bot.gateway.access_token",
+		"LANMEI_BOT_INTENT_TIMEOUT_SECONDS":      "bot.intent_timeout_seconds",
+		"LANMEI_BOT_TURTLE_SOUP_TIMEOUT_SECONDS": "bot.turtle_soup_timeout_seconds",
+		"LANMEI_AI_LLM_API_KEY":                  "ai.llm_api_key",
+		"LANMEI_AI_LLM_BASE_URL":                 "ai.llm_base_url",
+		"LANMEI_AI_LLM_MODEL":                    "ai.llm_model",
+		"LANMEI_AI_LLM_MAX_TOKENS":               "ai.llm_max_tokens",
+		"LANMEI_AI_LLM_TEMPERATURE":              "ai.llm_temperature",
+		"LANMEI_AI_EMBEDDING_API_KEY":            "ai.embedding_api_key",
+		"LANMEI_AI_EMBEDDING_BASE_URL":           "ai.embedding_base_url",
+		"LANMEI_AI_EMBEDDING_MODEL":              "ai.embedding_model",
+		"LANMEI_AI_EMBEDDING_DIM":                "ai.embedding_dim",
+		"LANMEI_PLUGIN_ROOT_DIR":                 "plugin.root_dir",
+		"LANMEI_PLUGIN_NCM_URL":                  "plugin.ncm_url",
+		"LANMEI_PLUGIN_MUSIC_SEND_MODE":          "plugin.music_send_mode",
+		"LANMEI_KNOWLEDGE_ENABLED":               "knowledge.enabled",
+		"LANMEI_KNOWLEDGE_AUTO_RECALL_LIMIT":     "knowledge.auto_recall_limit",
 		// 多媒体（RustFS）与机器人行为配置
 		"LANMEI_MEDIA_ENDPOINT":   "bot.media.endpoint",
 		"LANMEI_MEDIA_ACCESS_KEY": "bot.media.access_key",
@@ -130,11 +131,12 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("bot.nickname", "蓝妹")
 	v.SetDefault("bot.super_users", "")
 	v.SetDefault("bot.gateway.listen_addr", "0.0.0.0:8080")
-	v.SetDefault("bot.intent_timeout_seconds", 8)    // 意图分析独立超时 8s，LLM 故障时快速降级，避免吃满消息预算
-	v.SetDefault("bot.stream.typing_speed_ms", 150)  // 150ms/字，模拟打字速度
-	v.SetDefault("bot.stream.min_interval_ms", 1000) // 最小 1 秒
-	v.SetDefault("bot.stream.max_interval_ms", 5000) // 最大 5 秒（长消息段间隔上限，避免过久等待）
-	v.SetDefault("bot.stream.jitter_pct", 0.25)      // ±25% 抖动
+	v.SetDefault("bot.intent_timeout_seconds", 8)       // 意图分析独立超时 8s，LLM 故障时快速降级，避免吃满消息预算
+	v.SetDefault("bot.turtle_soup_timeout_seconds", 15) // 海龟汤出题/判定 LLM 独立超时 15s，超时回"汤煮糊了"而非迷糊兜底
+	v.SetDefault("bot.stream.typing_speed_ms", 150)     // 150ms/字，模拟打字速度
+	v.SetDefault("bot.stream.min_interval_ms", 1000)    // 最小 1 秒
+	v.SetDefault("bot.stream.max_interval_ms", 5000)    // 最大 5 秒（长消息段间隔上限，避免过久等待）
+	v.SetDefault("bot.stream.jitter_pct", 0.25)         // ±25% 抖动
 
 	// 多媒体（RustFS）默认值
 	v.SetDefault("bot.media.endpoint", "http://localhost:9000")


### PR DESCRIPTION

根因：插件所有 LLM 调用（出题 `generateSoup`、提问判定 `judgeQuestion`、猜答案判定 `judgeGuess`）都经由 `chatJSON` 直接使用**消息级上下文（20s 总预算）**，没有独立超时。LLM 慢时一次调用即可吃满预算，导致命令必然失败、甚至触发"迷糊"兜底。

## 修复逻辑

给海龟汤出题/判定 LLM 调用增加**独立超时**（默认 15s，可配置），与意图分析修复（`bot.intent_timeout_seconds`）同一模式：

- `chatJSON` 内部用 `context.WithTimeout` 包裹 LLM 调用，超时后快速失败返回；
- 超时/失败时命令管线快速降级回复「汤煮糊了」「蓝妹走神了」等话术，**不再耗尽消息预算触发"迷糊"兜底**；
- 配置项 `bot.turtle_soup_timeout_seconds`（环境变量 `LANMEI_BOT_TURTLE_SOUP_TIMEOUT_SECONDS`，默认 15，0 表示不设独立超时），经 `BusinessRegistry` 注入插件，`turtle_soup` 包不依赖 config 包。

## 改动清单

| 文件 | 改动 |
|---|---|
| `internal/bizplugin/turtle_soup.go` | `chatJSON` 增加 timeout 参数并包裹 LLM 调用；`generateSoup`/`judgeQuestion`/`judgeGuess` 透传；插件与 Pass 持有 timeout |
| `internal/config/config.go` | `BotConfig` 新增 `TurtleSoupTimeoutSeconds` |
| `internal/config/init.go` | 默认值 15s + 环境变量映射 |
| `internal/bizplugin/registry.go` | `SetTurtleSoupTimeout` + `NewTurtleSoupPlugin` 传参 |
| `cmd/lanmei/main.go` | 接线：从配置注入超时 |
| `.env.example` | 新增 `LANMEI_BOT_TURTLE_SOUP_TIMEOUT_SECONDS=15` |

## 验证

- `go build ./...` 通过
- `go test ./internal/bot/... ./internal/bizplugin/...` 通过