### PR TITLE
Feat/turtle soup async

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,9 @@ LANMEI_BOT_SUPER_USERS=
 # 意图分析 LLM 独立超时（秒）：意图分析只是路由前置步骤，
 # LLM 故障时快速降级，避免吃满消息预算（默认 20s）触发"迷糊"兜底回复
 LANMEI_BOT_INTENT_TIMEOUT_SECONDS=8
-# 海龟汤出题/判定 LLM 独立超时（秒）：LLM 慢时快速降级回"汤煮糊了"，不耗尽消息预算
-LANMEI_BOT_TURTLE_SOUP_TIMEOUT_SECONDS=15
+# 海龟汤出题/判定异步任务最长等待（秒）：命令立即回提示，后台独立 context 生成，
+# 不受消息 20s 预算约束（适配慢速/推理型 LLM）
+LANMEI_BOT_TURTLE_SOUP_TIMEOUT_SECONDS=120
 
 # ── LLM（OpenAI 兼容 API，支持 DeepSeek/Qwen/Moonshot/GLM 等）──
 # 填入 API Key 后角色扮演和意图分析自动启用

--- a/internal/ai/llm/client.go
+++ b/internal/ai/llm/client.go
@@ -60,6 +60,11 @@ type ChatRequest struct {
 	// 对推理型模型尤其重要：上限越大模型"思考"越久、响应越慢，
 	// 短输出场景（意图分类、海龟汤出题/判定）应显式设小值控制耗时。
 	MaxTokens *int `json:"max_tokens,omitempty"`
+	// ReasoningEffort 本次请求的推理强度（"low"/"medium"/"high"，nil 时沿用默认）。
+	// 推理型模型（如 deepseek-v4-flash）在默认强度下会长时间"思考"甚至把输出预算
+	// 全部花在 reasoning 上导致 content 为空；结构化短输出场景（海龟汤 JSON）应设 "low"，
+	// 关闭过度思考，响应可降至秒级。
+	ReasoningEffort *string `json:"reasoning_effort,omitempty"`
 }
 
 // ChatResponse 是对话服务的返回

--- a/internal/ai/llm/client.go
+++ b/internal/ai/llm/client.go
@@ -60,11 +60,10 @@ type ChatRequest struct {
 	// 对推理型模型尤其重要：上限越大模型"思考"越久、响应越慢，
 	// 短输出场景（意图分类、海龟汤出题/判定）应显式设小值控制耗时。
 	MaxTokens *int `json:"max_tokens,omitempty"`
-	// ReasoningEffort 本次请求的推理强度（"low"/"medium"/"high"，nil 时沿用默认）。
-	// 推理型模型（如 deepseek-v4-flash）在默认强度下会长时间"思考"甚至把输出预算
-	// 全部花在 reasoning 上导致 content 为空；结构化短输出场景（海龟汤 JSON）应设 "low"，
-	// 关闭过度思考，响应可降至秒级。
-	ReasoningEffort *string `json:"reasoning_effort,omitempty"`
+	// DisableThinking 是否禁用推理模型的"思考"（DeepSeek 等通过 thinking={"type":"disabled"} 支持）。
+	// 推理模型默认会长时间思考，甚至把输出预算全部花在 reasoning 上导致 content 为空；
+	// 结构化短输出场景（海龟汤 JSON）应禁用思考，响应可降至秒级。
+	DisableThinking *bool `json:"-"`
 }
 
 // ChatResponse 是对话服务的返回

--- a/internal/ai/llm/client.go
+++ b/internal/ai/llm/client.go
@@ -56,6 +56,10 @@ type ChatRequest struct {
 	Platform     string        `json:"platform,omitempty"`      // 消息平台（qq/wechat/telegram…），供计费统计
 	Scene        string        `json:"scene,omitempty"`         // 用量场景（chat/intent/compress/topic/vision），供计费统计
 	TopicContext *TopicContext `json:"topic_context,omitempty"` // 群聊话题上下文（nil = 私聊/无话题）
+	// MaxTokens 本次请求的输出 token 上限（nil 时沿用 client 全局配置）。
+	// 对推理型模型尤其重要：上限越大模型"思考"越久、响应越慢，
+	// 短输出场景（意图分类、海龟汤出题/判定）应显式设小值控制耗时。
+	MaxTokens *int `json:"max_tokens,omitempty"`
 }
 
 // ChatResponse 是对话服务的返回

--- a/internal/ai/llm/eino.go
+++ b/internal/ai/llm/eino.go
@@ -109,7 +109,13 @@ func (c *EinoClient) ChatWithTools(tools []*schema.ToolInfo) (model.BaseChatMode
 func (c *EinoClient) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
 	msgs := ToSchemaMessages(req.Messages)
 
-	resp, err := c.model.Generate(ctx, msgs)
+	var opts []model.Option
+	if req.MaxTokens != nil {
+		// 按请求覆盖输出上限（推理模型对 max_tokens 敏感，短输出场景必须显式设小值）
+		opts = append(opts, model.WithMaxTokens(*req.MaxTokens))
+	}
+
+	resp, err := c.model.Generate(ctx, msgs, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("llm: eino generate: %w", err)
 	}

--- a/internal/ai/llm/eino.go
+++ b/internal/ai/llm/eino.go
@@ -114,6 +114,10 @@ func (c *EinoClient) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse,
 		// 按请求覆盖输出上限（推理模型对 max_tokens 敏感，短输出场景必须显式设小值）
 		opts = append(opts, model.WithMaxTokens(*req.MaxTokens))
 	}
+	if req.ReasoningEffort != nil {
+		// 按请求覆盖推理强度（"low" 让推理模型快速收敛，避免思考耗尽预算导致 content 为空）
+		opts = append(opts, openai.WithReasoningEffort(openai.ReasoningEffortLevel(*req.ReasoningEffort)))
+	}
 
 	resp, err := c.model.Generate(ctx, msgs, opts...)
 	if err != nil {

--- a/internal/ai/llm/eino.go
+++ b/internal/ai/llm/eino.go
@@ -114,9 +114,12 @@ func (c *EinoClient) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse,
 		// 按请求覆盖输出上限（推理模型对 max_tokens 敏感，短输出场景必须显式设小值）
 		opts = append(opts, model.WithMaxTokens(*req.MaxTokens))
 	}
-	if req.ReasoningEffort != nil {
-		// 按请求覆盖推理强度（"low" 让推理模型快速收敛，避免思考耗尽预算导致 content 为空）
-		opts = append(opts, openai.WithReasoningEffort(openai.ReasoningEffortLevel(*req.ReasoningEffort)))
+	if req.DisableThinking != nil && *req.DisableThinking {
+		// DeepSeek 等推理模型通过 thinking={"type":"disabled"} 关闭思考，
+		// 经 eino 的 ExtraFields 透传（OpenAI 兼容扩展字段）
+		opts = append(opts, openai.WithExtraFields(map[string]any{
+			"thinking": map[string]any{"type": "disabled"},
+		}))
 	}
 
 	resp, err := c.model.Generate(ctx, msgs, opts...)

--- a/internal/bizplugin/turtle_soup.go
+++ b/internal/bizplugin/turtle_soup.go
@@ -172,7 +172,7 @@ type turtleQA struct {
 type turtleGame struct {
 	SoupFace      string     `json:"soup_face"`      // 汤面（公开谜面）
 	SoupBase      string     `json:"soup_base"`      // 汤底（答案，隐藏）
-	Hints         string     `json:"hints"`          // 判定要点（内部参考，不公开）
+	Hints         []string   `json:"hints"`          // 判定要点（内部参考，不公开）
 	QuestionCount int        `json:"question_count"` // 已提问次数
 	Creator       string     `json:"creator"`        // 开局人
 	CreatedAt     int64      `json:"created_at"`     // 开局时间戳
@@ -229,9 +229,9 @@ func saveGame(kv *database.PluginKVStore, ctx context.Context, groupID, userID s
 
 // turtleGeneration LLM 出题结果
 type turtleGeneration struct {
-	SoupFace string `json:"soup_face"`
-	SoupBase string `json:"soup_base"`
-	Hints    string `json:"hints"`
+	SoupFace string   `json:"soup_face"`
+	SoupBase string   `json:"soup_base"`
+	Hints    []string `json:"hints"` // 判定要点列表（模型输出数组）
 }
 
 // turtleJudgement LLM 判定结果（提问）
@@ -248,6 +248,9 @@ type turtleGuessResult struct {
 
 // intPtr 返回 int 的指针（ChatRequest.MaxTokens 为 *int，nil 表示沿用全局配置）。
 func intPtr(v int) *int { return &v }
+
+// strPtr 返回 string 的指针（ChatRequest.ReasoningEffort 为 *string）。
+func strPtr(v string) *string { return &v }
 
 // chatJSON 调用 LLM 并解析 JSON 响应（容错：剥离 markdown 代码块围栏）。
 // timeout > 0 时为 LLM 调用设置独立超时：LLM 慢/故障时快速降级返回，
@@ -267,7 +270,8 @@ func chatJSON(ctx context.Context, client llm.LLMClient, system, user string, ou
 			{Role: llm.RoleSystem, Content: system},
 			{Role: llm.RoleUser, Content: user},
 		},
-		MaxTokens: intPtr(turtleSoupMaxTokens),
+		MaxTokens:       intPtr(turtleSoupMaxTokens),
+		ReasoningEffort: strPtr(turtleSoupReasoningEffort),
 	})
 	if err != nil {
 		return fmt.Errorf("LLM 调用失败: %w", err)
@@ -286,9 +290,9 @@ func generateSoup(ctx context.Context, client llm.LLMClient, timeout time.Durati
 	const system = `你是一个海龟汤（情境推理谜题）出题人。请生成一个经典风格的海龟汤谜题：
 - 汤面（soup_face）：简短、离奇、让人困惑的情境描述（1-3 句话），只陈述现象，不含任何解释
 - 汤底（soup_base）：完整合理的真相（1-3 句话），能自洽解释汤面
-- 判定要点（hints）：供主持人回答"是/否/无关"时参考的关键事实（严禁出现完整答案）
+- 判定要点（hints）：供主持人回答"是/否/无关"时参考的关键事实列表（2-4 条，严禁出现完整答案）
 要求：情境不得涉及血腥、暴力、色情、违法或不适内容，适合校园群聊；谜题要有趣且逻辑自洽。
-仅输出 JSON，不要其他内容：{"soup_face":"...","soup_base":"...","hints":"..."}`
+仅输出 JSON，不要其他内容：{"soup_face":"...","soup_base":"...","hints":["...","..."]}`
 	resp := &turtleGeneration{}
 	if err := chatJSON(ctx, client, system, "请生成一局海龟汤。", resp, timeout); err != nil {
 		return nil, err
@@ -299,7 +303,7 @@ func generateSoup(ctx context.Context, client llm.LLMClient, timeout time.Durati
 	return &turtleGame{
 		SoupFace:  strings.TrimSpace(resp.SoupFace),
 		SoupBase:  strings.TrimSpace(resp.SoupBase),
-		Hints:     strings.TrimSpace(resp.Hints),
+		Hints:     resp.Hints,
 		CreatedAt: time.Now().Unix(),
 	}, nil
 }
@@ -310,7 +314,7 @@ func judgeQuestion(ctx context.Context, client llm.LLMClient, g *turtleGame, que
 	sb.WriteString("你正在主持一个海龟汤（情境推理）游戏，只回答 是/否/无关。\n\n")
 	sb.WriteString("汤面：" + g.SoupFace + "\n")
 	sb.WriteString("汤底：" + g.SoupBase + "\n")
-	sb.WriteString("判定要点：" + g.Hints + "\n")
+	sb.WriteString("判定要点：" + strings.Join(g.Hints, "；") + "\n")
 	if len(g.QAPairs) > 0 {
 		sb.WriteString("\n玩家已提问（历史）：\n")
 		for i, qa := range g.QAPairs {
@@ -382,6 +386,11 @@ const streamTimeout = 120 * time.Second
 // 推理模型对 max_tokens 敏感（上限越大思考越久、响应越慢），
 // 出题/判定只需几百 token 的 JSON，设 1024 可让模型收敛、显著提速。
 const turtleSoupMaxTokens = 1024
+
+// turtleSoupReasoningEffort 海龟汤 LLM 调用的推理强度。
+// deepseek-v4-flash 等推理模型默认强度下会长时间"思考"，甚至把输出预算全部
+// 花在 reasoning 上导致 content 为空；设 "low" 关闭过度思考，响应降至秒级。
+const turtleSoupReasoningEffort = "low"
 
 func (pass *turtleSoupPass) Execute(ctx *conduit.MessageContext) error {
 	msg := strings.TrimSpace(ctx.RawMsg)

--- a/internal/bizplugin/turtle_soup.go
+++ b/internal/bizplugin/turtle_soup.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/DaWesen/lanmei-dream/internal/ai/llm"
@@ -78,7 +79,7 @@ func (p *TurtleSoupPlugin) OnInit(ctx *pluginpkg.PluginContext) error {
 	p.kv = ctx.KV
 
 	passID := pluginpkg.PassID("turtle_soup", "main")
-	pass := &turtleSoupPass{llmClient: p.llmClient, kv: p.kv, logger: p.logger, timeout: p.timeout}
+	pass := &turtleSoupPass{llmClient: p.llmClient, kv: p.kv, logger: p.logger, timeout: p.timeout, inFlight: map[string]bool{}}
 	if err := ctx.Engine.RegisterPass(passID, pass); err != nil {
 		return fmt.Errorf("register turtle_soup pass: %w", err)
 	}
@@ -245,6 +246,9 @@ type turtleGuessResult struct {
 	Comment string `json:"comment"`
 }
 
+// intPtr 返回 int 的指针（ChatRequest.MaxTokens 为 *int，nil 表示沿用全局配置）。
+func intPtr(v int) *int { return &v }
+
 // chatJSON 调用 LLM 并解析 JSON 响应（容错：剥离 markdown 代码块围栏）。
 // timeout > 0 时为 LLM 调用设置独立超时：LLM 慢/故障时快速降级返回，
 // 避免耗尽消息级预算（20s）触发"迷糊"兜底；<=0 则沿用传入 ctx。
@@ -263,6 +267,7 @@ func chatJSON(ctx context.Context, client llm.LLMClient, system, user string, ou
 			{Role: llm.RoleSystem, Content: system},
 			{Role: llm.RoleUser, Content: user},
 		},
+		MaxTokens: intPtr(turtleSoupMaxTokens),
 	})
 	if err != nil {
 		return fmt.Errorf("LLM 调用失败: %w", err)
@@ -349,12 +354,34 @@ func judgeGuess(ctx context.Context, client llm.LLMClient, g *turtleGame, guess 
 // ============================================================
 
 // turtleSoupPass 按命令前缀分发处理海龟汤请求。
+//
+// LLM 出题/判定采用**异步模式**：命令到达后立即回复提示语并挂起管线（yield），
+// 后台 goroutine 用独立长超时调用 LLM（不占消息 20s 预算，多慢都能完成），
+// 完成后经段落投递通道（bot.stream.ch）自动发送结果。
+// 这是为适配慢速/推理型 LLM（响应 10~30s 波动）的必要设计：同步等待必然超时。
 type turtleSoupPass struct {
 	llmClient llm.LLMClient
 	kv        *database.PluginKVStore
 	logger    *zap.Logger
-	timeout   time.Duration // 出题/判定 LLM 调用独立超时（<=0 不限制）
+	timeout   time.Duration // 异步出题/判定的最长等待（goroutine 独立 context 上限）
+
+	// mu 保护游戏状态临界区（loadGame/saveGame）与 inFlight 标记。
+	// LLM 调用本身在锁外执行（慢网络调用不持锁），由 inFlight 保证同一群同时只有一个异步任务。
+	mu       sync.Mutex
+	inFlight map[string]bool // soupKey → 是否有进行中的异步出题/判定
 }
+
+// streamChannelKey 段落投递通道键（复用 bot 层的流式段落机制，见 internal/bot/passes.go；
+// 按 bizplugin 约定不 import bot 包，直接使用字符串字面量）。
+const streamChannelKey = "bot.stream.ch"
+
+// streamTimeout 异步出题/判定的独立上下文超时（配置 turtle_soup_timeout_seconds<=0 时的兜底）。
+const streamTimeout = 120 * time.Second
+
+// turtleSoupMaxTokens 海龟汤 LLM 调用（出题/判定）的输出 token 上限。
+// 推理模型对 max_tokens 敏感（上限越大思考越久、响应越慢），
+// 出题/判定只需几百 token 的 JSON，设 1024 可让模型收敛、显著提速。
+const turtleSoupMaxTokens = 1024
 
 func (pass *turtleSoupPass) Execute(ctx *conduit.MessageContext) error {
 	msg := strings.TrimSpace(ctx.RawMsg)
@@ -380,33 +407,84 @@ func (pass *turtleSoupPass) reply(ctx *conduit.MessageContext, content string) {
 	})
 }
 
-// open 开一局海龟汤（一个群同时只能一局）。
+// beginAsync 启动一个异步 LLM 任务并挂起管线（yield）。
+//
+// 工作方式（复用 bot 层流式段落投递机制）：
+//  1. 登记 inFlight（同一群同时只允许一个异步任务，防并发覆盖游戏状态）；
+//  2. 同步回复 hint 提示语；
+//  3. 将结果通道写入黑板（streamChannelKey），返回 ErrPassYielded；
+//  4. 引擎 yield 后，bot 消费通道把 fn 写入的结果作为段落自动发送。
+//
+// fn 在后台 goroutine 执行，使用独立长超时 context（不受消息 20s 预算约束），
+// 结果（最终回复文案）写入 ch，函数返回前由调用方保证 saveGame 已完成。
+func (pass *turtleSoupPass) beginAsync(ctx *conduit.MessageContext, key, hint string, fn func(gctx context.Context, ch chan<- string)) error {
+	pass.mu.Lock()
+	if pass.inFlight[key] {
+		pass.mu.Unlock()
+		pass.reply(ctx, "蓝妹正在处理上一个请求，稍等一下~")
+		return nil
+	}
+	pass.inFlight[key] = true
+	pass.mu.Unlock()
+
+	pass.reply(ctx, hint)
+	ch := make(chan string, 1)
+	conduit.Set(ctx, streamChannelKey, ch)
+	go func() {
+		defer close(ch)
+		defer func() {
+			pass.mu.Lock()
+			delete(pass.inFlight, key)
+			pass.mu.Unlock()
+		}()
+		gctx, cancel := context.WithTimeout(context.Background(), pass.asyncTimeout())
+		defer cancel()
+		fn(gctx, ch)
+	}()
+	return conduit.ErrPassYielded
+}
+
+// asyncTimeout 返回异步任务的独立超时（配置 turtle_soup_timeout_seconds，
+// <=0 时退化为固定 120s）。
+func (pass *turtleSoupPass) asyncTimeout() time.Duration {
+	if pass.timeout > 0 {
+		return pass.timeout
+	}
+	return streamTimeout
+}
+
+// open 开一局海龟汤（一个群同时只能一局）。出题异步进行，不阻塞消息预算。
 func (pass *turtleSoupPass) open(ctx *conduit.MessageContext) error {
 	if pass.llmClient == nil {
 		pass.reply(ctx, "海龟汤需要 LLM 才能出题，当前未配置~")
 		return nil
 	}
-	if existing := loadGame(pass.kv, ctx.Ctx, ctx.GroupID, ctx.UserID); existing != nil {
-		pass.reply(ctx, "本群已经有一锅汤在炖啦！先 `/认输` 结束这局，再开新的 (´･ω･`)")
-		return nil
-	}
-
-	pass.reply(ctx, "正在煮汤，稍等一下…")
-	game, err := generateSoup(ctx.Ctx, pass.llmClient, pass.timeout)
-	if err != nil {
-		pass.logger.Warn("turtle_soup: 出题失败", zap.Error(err))
-		pass.reply(ctx, "汤煮糊了，稍后再试一次吧 (￣ω￣;)")
-		return nil
-	}
-	game.Creator = ctx.UserID
-
-	saveGame(pass.kv, ctx.Ctx, ctx.GroupID, ctx.UserID, game)
-	pass.reply(ctx, fmt.Sprintf(
-		"海龟汤开张啦！\n——\n%s\n——\n\n用 `/问 <问题>` 提问（蓝妹只答 是/否/无关），`/猜 <答案>` 猜汤底，`/认输` 看答案。", game.SoupFace))
-	return nil
+	return pass.beginAsync(ctx, soupKey(ctx.GroupID, ctx.UserID), "正在煮汤，稍等一下…",
+		func(gctx context.Context, ch chan<- string) {
+			pass.mu.Lock()
+			existing := loadGame(pass.kv, gctx, ctx.GroupID, ctx.UserID)
+			pass.mu.Unlock()
+			if existing != nil {
+				ch <- "本群已经有一锅汤在炖啦！先 `/认输` 结束这局，再开新的 (´･ω･`)"
+				return
+			}
+			game, err := generateSoup(gctx, pass.llmClient, pass.asyncTimeout())
+			if err != nil {
+				pass.logger.Warn("turtle_soup: 出题失败", zap.Error(err))
+				ch <- "汤煮糊了，稍后再试一次吧 (￣ω￣;)"
+				return
+			}
+			game.Creator = ctx.UserID
+			pass.mu.Lock()
+			saveGame(pass.kv, gctx, ctx.GroupID, ctx.UserID, game)
+			pass.mu.Unlock()
+			ch <- fmt.Sprintf(
+				"海龟汤开张啦！\n——\n%s\n——\n\n用 `/问 <问题>` 提问（蓝妹只答 是/否/无关），`/猜 <答案>` 猜汤底，`/认输` 看答案。",
+				game.SoupFace)
+		})
 }
 
-// ask 处理提问（仅在有进行中的局时生效）。
+// ask 处理提问（仅在有进行中的局时生效）。判定异步进行。
 func (pass *turtleSoupPass) ask(ctx *conduit.MessageContext, question string) error {
 	if question == "" {
 		pass.reply(ctx, "格式：/问 <问题>，比如 `/问 他是因为停电死的吗`")
@@ -416,31 +494,35 @@ func (pass *turtleSoupPass) ask(ctx *conduit.MessageContext, question string) er
 		pass.reply(ctx, "海龟汤需要 LLM 才能判定，当前未配置~")
 		return nil
 	}
-	game := loadGame(pass.kv, ctx.Ctx, ctx.GroupID, ctx.UserID)
-	if game == nil {
-		pass.reply(ctx, "现在没有进行中的汤，用 `/开汤` 开一局吧")
-		return nil
-	}
-	if game.QuestionCount >= turtleSoupMaxQuestions {
-		pass.reply(ctx, "这锅汤已经问了太多啦，直接 `/猜` 或 `/认输` 吧")
-		return nil
-	}
-
-	answer, err := judgeQuestion(ctx.Ctx, pass.llmClient, game, question, pass.timeout)
-	if err != nil {
-		pass.logger.Warn("turtle_soup: 判定失败", zap.Error(err))
-		pass.reply(ctx, "蓝妹走神了，再问一次吧 (￣ω￣;)")
-		return nil
-	}
-	game.QuestionCount++
-	game.QAPairs = append(game.QAPairs, turtleQA{Q: question, A: answer})
-	saveGame(pass.kv, ctx.Ctx, ctx.GroupID, ctx.UserID, game)
-
-	pass.reply(ctx, answer)
-	return nil
+	return pass.beginAsync(ctx, soupKey(ctx.GroupID, ctx.UserID), "蓝妹在琢磨你的问题…",
+		func(gctx context.Context, ch chan<- string) {
+			pass.mu.Lock()
+			game := loadGame(pass.kv, gctx, ctx.GroupID, ctx.UserID)
+			pass.mu.Unlock()
+			if game == nil {
+				ch <- "现在没有进行中的汤，用 `/开汤` 开一局吧"
+				return
+			}
+			if game.QuestionCount >= turtleSoupMaxQuestions {
+				ch <- "这锅汤已经问了太多啦，直接 `/猜` 或 `/认输` 吧"
+				return
+			}
+			answer, err := judgeQuestion(gctx, pass.llmClient, game, question, pass.asyncTimeout())
+			if err != nil {
+				pass.logger.Warn("turtle_soup: 判定失败", zap.Error(err))
+				ch <- "蓝妹走神了，再问一次吧 (￣ω￣;)"
+				return
+			}
+			game.QuestionCount++
+			game.QAPairs = append(game.QAPairs, turtleQA{Q: question, A: answer})
+			pass.mu.Lock()
+			saveGame(pass.kv, gctx, ctx.GroupID, ctx.UserID, game)
+			pass.mu.Unlock()
+			ch <- answer
+		})
 }
 
-// guess 猜汤底，命中则揭晓结算。
+// guess 猜汤底，命中则揭晓结算。判定异步进行。
 func (pass *turtleSoupPass) guess(ctx *conduit.MessageContext, guess string) error {
 	if guess == "" {
 		pass.reply(ctx, "格式：/猜 <答案>，比如 `/猜 他是冻死的`")
@@ -450,31 +532,41 @@ func (pass *turtleSoupPass) guess(ctx *conduit.MessageContext, guess string) err
 		pass.reply(ctx, "海龟汤需要 LLM 才能判定，当前未配置~")
 		return nil
 	}
-	game := loadGame(pass.kv, ctx.Ctx, ctx.GroupID, ctx.UserID)
-	if game == nil {
-		pass.reply(ctx, "现在没有进行中的汤，用 `/开汤` 开一局吧")
-		return nil
-	}
-
-	correct, comment, err := judgeGuess(ctx.Ctx, pass.llmClient, game, guess, pass.timeout)
-	if err != nil {
-		pass.logger.Warn("turtle_soup: 猜答案判定失败", zap.Error(err))
-		pass.reply(ctx, "蓝妹走神了，再猜一次吧 (￣ω￣;)")
-		return nil
-	}
-	if !correct {
-		pass.reply(ctx, "不是这个答案"+withComment(comment)+"，再想想看~")
-		return nil
-	}
-
-	pass.reply(ctx, fmt.Sprintf(
-		"🎉 猜对啦！汤底是：\n%s\n%s", game.SoupBase, withComment(comment)))
-	saveGame(pass.kv, ctx.Ctx, ctx.GroupID, ctx.UserID, nil) // 结算，清除本局
-	return nil
+	return pass.beginAsync(ctx, soupKey(ctx.GroupID, ctx.UserID), "蓝妹在琢磨你的答案…",
+		func(gctx context.Context, ch chan<- string) {
+			pass.mu.Lock()
+			game := loadGame(pass.kv, gctx, ctx.GroupID, ctx.UserID)
+			pass.mu.Unlock()
+			if game == nil {
+				ch <- "现在没有进行中的汤，用 `/开汤` 开一局吧"
+				return
+			}
+			correct, comment, err := judgeGuess(gctx, pass.llmClient, game, guess, pass.asyncTimeout())
+			if err != nil {
+				pass.logger.Warn("turtle_soup: 猜答案判定失败", zap.Error(err))
+				ch <- "蓝妹走神了，再猜一次吧 (￣ω￣;)"
+				return
+			}
+			if !correct {
+				ch <- "不是这个答案" + withComment(comment) + "，再想想看~"
+				return
+			}
+			pass.mu.Lock()
+			saveGame(pass.kv, gctx, ctx.GroupID, ctx.UserID, nil) // 结算，清除本局
+			pass.mu.Unlock()
+			ch <- fmt.Sprintf("🎉 猜对啦！汤底是：\n%s\n%s", game.SoupBase, withComment(comment))
+		})
 }
 
-// giveUp 放弃并揭晓汤底。
+// giveUp 放弃并揭晓汤底（无 LLM 调用，同步完成）。
 func (pass *turtleSoupPass) giveUp(ctx *conduit.MessageContext) error {
+	key := soupKey(ctx.GroupID, ctx.UserID)
+	pass.mu.Lock()
+	defer pass.mu.Unlock()
+	if pass.inFlight[key] {
+		pass.reply(ctx, "蓝妹正在处理上一个请求，稍等一下再认输~")
+		return nil
+	}
 	game := loadGame(pass.kv, ctx.Ctx, ctx.GroupID, ctx.UserID)
 	if game == nil {
 		pass.reply(ctx, "现在没有进行中的汤，用 `/开汤` 开一局吧")

--- a/internal/bizplugin/turtle_soup.go
+++ b/internal/bizplugin/turtle_soup.go
@@ -249,8 +249,8 @@ type turtleGuessResult struct {
 // intPtr 返回 int 的指针（ChatRequest.MaxTokens 为 *int，nil 表示沿用全局配置）。
 func intPtr(v int) *int { return &v }
 
-// strPtr 返回 string 的指针（ChatRequest.ReasoningEffort 为 *string）。
-func strPtr(v string) *string { return &v }
+// boolPtr 返回 bool 的指针（ChatRequest.DisableThinking 为 *bool）。
+func boolPtr(v bool) *bool { return &v }
 
 // chatJSON 调用 LLM 并解析 JSON 响应（容错：剥离 markdown 代码块围栏）。
 // timeout > 0 时为 LLM 调用设置独立超时：LLM 慢/故障时快速降级返回，
@@ -271,7 +271,7 @@ func chatJSON(ctx context.Context, client llm.LLMClient, system, user string, ou
 			{Role: llm.RoleUser, Content: user},
 		},
 		MaxTokens:       intPtr(turtleSoupMaxTokens),
-		ReasoningEffort: strPtr(turtleSoupReasoningEffort),
+		DisableThinking: boolPtr(true),
 	})
 	if err != nil {
 		return fmt.Errorf("LLM 调用失败: %w", err)
@@ -386,11 +386,6 @@ const streamTimeout = 120 * time.Second
 // 推理模型对 max_tokens 敏感（上限越大思考越久、响应越慢），
 // 出题/判定只需几百 token 的 JSON，设 1024 可让模型收敛、显著提速。
 const turtleSoupMaxTokens = 1024
-
-// turtleSoupReasoningEffort 海龟汤 LLM 调用的推理强度。
-// deepseek-v4-flash 等推理模型默认强度下会长时间"思考"，甚至把输出预算全部
-// 花在 reasoning 上导致 content 为空；设 "low" 关闭过度思考，响应降至秒级。
-const turtleSoupReasoningEffort = "low"
 
 func (pass *turtleSoupPass) Execute(ctx *conduit.MessageContext) error {
 	msg := strings.TrimSpace(ctx.RawMsg)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -144,9 +144,9 @@ type BotConfig struct {
 	// LLM 故障时快速降级，避免后续对话管线失去剩余时间、触发"迷糊"兜底。
 	// 0 表示不设独立超时（沿用消息级超时，默认 20s）。
 	IntentTimeoutSeconds int `mapstructure:"intent_timeout_seconds"`
-	// TurtleSoupTimeoutSeconds 海龟汤插件出题/判定的 LLM 独立超时（秒）。
-	// 命令管线同样受消息级超时约束，LLM 慢时给独立上限可快速降级
-	//（回"汤煮糊了"），避免耗尽预算触发"迷糊"兜底。0 表示不设独立超时。
+	// TurtleSoupTimeoutSeconds 海龟汤出题/判定的异步任务最长等待（秒）。
+	// 命令到达后立即回复提示并挂起管线，LLM 在后台 goroutine 以独立 context 执行，
+	// 不受消息级超时约束；本值是其上限（默认 120s），<=0 时用固定 120s。
 	TurtleSoupTimeoutSeconds int `mapstructure:"turtle_soup_timeout_seconds"`
 }
 

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -131,12 +131,12 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("bot.nickname", "蓝妹")
 	v.SetDefault("bot.super_users", "")
 	v.SetDefault("bot.gateway.listen_addr", "0.0.0.0:8080")
-	v.SetDefault("bot.intent_timeout_seconds", 8)       // 意图分析独立超时 8s，LLM 故障时快速降级，避免吃满消息预算
-	v.SetDefault("bot.turtle_soup_timeout_seconds", 15) // 海龟汤出题/判定 LLM 独立超时 15s，超时回"汤煮糊了"而非迷糊兜底
-	v.SetDefault("bot.stream.typing_speed_ms", 150)     // 150ms/字，模拟打字速度
-	v.SetDefault("bot.stream.min_interval_ms", 1000)    // 最小 1 秒
-	v.SetDefault("bot.stream.max_interval_ms", 5000)    // 最大 5 秒（长消息段间隔上限，避免过久等待）
-	v.SetDefault("bot.stream.jitter_pct", 0.25)         // ±25% 抖动
+	v.SetDefault("bot.intent_timeout_seconds", 8)        // 意图分析独立超时 8s，LLM 故障时快速降级，避免吃满消息预算
+	v.SetDefault("bot.turtle_soup_timeout_seconds", 120) // 海龟汤异步出题/判定最长等待 120s（独立 context，不占消息预算）
+	v.SetDefault("bot.stream.typing_speed_ms", 150)      // 150ms/字，模拟打字速度
+	v.SetDefault("bot.stream.min_interval_ms", 1000)     // 最小 1 秒
+	v.SetDefault("bot.stream.max_interval_ms", 5000)     // 最大 5 秒（长消息段间隔上限，避免过久等待）
+	v.SetDefault("bot.stream.jitter_pct", 0.25)          // ±25% 抖动
 
 	// 多媒体（RustFS）默认值
 	v.SetDefault("bot.media.endpoint", "http://localhost:9000")


### PR DESCRIPTION
## 问题描述

海龟汤插件（`/开汤` `/问` `/猜`）的 LLM 调用在 DeepSeek 推理模型（deepseek-v4-flash）下持续失败：

1. **超时**：`max_tokens=4096`（全局配置）下推理模型长时间"思考"，调用 30s+ 超时（`context deadline exceeded`），即使加独立超时也频繁失败；
2. **空输出**：限制 `max_tokens` 后（1024/2048），模型把预算全部花在 `reasoning_content` 思考上，正式输出 `content` 为空 → `unexpected end of JSON input`；
3. 同步调用还受消息级 20s 预算约束，慢 LLM 会拖垮整个消息管线。

## 修复逻辑

**异步化**（根治超时）：`/开汤` `/问` `/猜` 命令到达后立即回复提示语并挂起管线（yield），LLM 调用放到后台 goroutine（独立 120s context，不占消息 20s 预算），完成后经 bot 层流式段落投递机制自动发送结果。LLM 再慢也能成功，且不阻塞其他消息。

**禁用思考**（根治空输出）：通过 eino 官方 `WithExtraFields` 透传 DeepSeek 原生参数 `thinking={"type":"disabled"}`，关闭推理模型的"思考"阶段——curl 实测：开启后 3s 内返回完整 JSON（此前 30s+ 且 content 为空）。

**输出上限**：海龟汤调用显式 `max_tokens=1024`（覆盖全局 4096），配合禁用思考让响应稳定在秒级。

**并发安全**：`inFlight` 标记 + mutex 保证同一群同时只有一个异步任务，游戏状态读写不竞态。

## 改动清单

| 文件 | 改动 |
|---|---|
| `internal/ai/llm/client.go` | `ChatRequest` 新增 `MaxTokens`、`DisableThinking` 字段（nil 时沿用全局，默认行为不变） |
| `internal/ai/llm/eino.go` | `Chat` 按请求应用 `max_tokens` 与 `thinking=disabled`（`WithExtraFields` 透传） |
| `internal/bizplugin/turtle_soup.go` | 出题/判定改异步（yield + goroutine）；`chatJSON` 设 `max_tokens=1024` + 禁用思考；`hints` 改 `[]string` 适配模型数组输出；`/认输` 同步 |
| `internal/config/config.go` | `TurtleSoupTimeoutSeconds` 语义改为异步等待上限（默认 120s） |
| `internal/config/init.go` | 默认值 15→120 |
| `.env.example` | 注释与默认值更新 |

## 验证

- `go build ./...` 通过；`go test ./internal/bot/... ./internal/bizplugin/...` 通过
- 生产环境实测（deepseek-v4-flash）：
  - `/开汤` 立即回「正在煮汤」→ 数秒内收到完整谜题 JSON（此前 30s 超时/空输出）
  - 出题期间普通消息正常秒回，不排队不阻塞

## 影响范围

仅海龟汤插件。`MaxTokens`/`DisableThinking` 是 llm 层可选能力，其他调用（意图分析、角色扮演、记忆压缩）不设置，行为完全不变。

## 部署

`docker compose up -d --build lanmei`；服务器 `.env` 无需新增配置（`turtle_soup_timeout_seconds` 默认 120 生效）。