### PR TITLE
feat: /表情列表 指令、/发表情 无参默认随机表情、/music 免@触发、表情提示词计数器

### DIFF
--- a/cmd/lanmei/main.go
+++ b/cmd/lanmei/main.go
@@ -296,9 +296,16 @@ func main() {
 
 	// 硬性表情规则：把表情库插件的随机表情能力注入 Bot（未启用/未注册时自动跳过）。
 	// 使 bot 每回复 10~20 条消息会周期性附带一张表情，不依赖 LLM 主动调用。
+	// 同时装配表情提示词计数器：统计 Bot 在本群/私聊的自然语言回复数，
+	// 以"当前计数{count}"注入 System Prompt，引导 LLM 约每五到十句发一次表情。
 	if p, ok := pluginReg.Get("sticker"); ok {
 		if inj, ok := p.(bot.StickerEmotionInjector); ok {
 			b.SetStickerInjector(inj)
+			counter := ai.NewReplyCounter()
+			if chatSvc != nil {
+				chatSvc.SetReplyCounter(counter)
+			}
+			b.SetStickerCounter(counter)
 		}
 	}
 

--- a/internal/ai/chat.go
+++ b/internal/ai/chat.go
@@ -48,6 +48,7 @@ type ChatService struct {
 	promptMgr  *prompt.Manager // Prompt 管理器（可选，为 nil 时使用 DefaultSystemPrompt）
 	knowledge  *kbpkg.Service  // 知识库系统（可选，为 nil 时跳过隐式召回）
 	usageHook  llm.UsageHook   // 用量上报回调（工具循环/流式路径专用；直连路径由 EinoClient 内部上报）
+	replyCount *ReplyCounter   // 表情提示词计数器（按群/私聊统计 Bot 自然语言回复数，可选，为 nil 时禁用）
 	logger     *zap.Logger
 }
 
@@ -86,6 +87,37 @@ func (s *ChatService) SetKnowledge(svc *kbpkg.Service) {
 // 直连路径（client.Chat 直接命中 EinoClient）由 EinoClient 内部 hook 上报，不会重复。
 func (s *ChatService) SetUsageHook(hook llm.UsageHook) {
 	s.usageHook = hook
+}
+
+// SetReplyCounter 注入表情提示词计数器。
+// 注入后 System Prompt 会附带"当前计数{count}"，count 统计 Bot 在本群/私聊中
+// 发出的自然语言（LLM 触发）回复数；为 nil 时跳过注入（表情库插件未启用）。
+func (s *ChatService) SetReplyCounter(c *ReplyCounter) {
+	s.replyCount = c
+}
+
+// IncReplyCount 在 Bot 完成一轮自然语言回复后调用，累加对应群/私聊作用域的计数。
+func (s *ChatService) IncReplyCount(scope string) {
+	if s.replyCount == nil {
+		return
+	}
+	s.replyCount.Inc(scope)
+}
+
+// ResetReplyCount 在 Bot 实际发表情后调用，清零对应群/私聊作用域的计数。
+func (s *ChatService) ResetReplyCount(scope string) {
+	if s.replyCount == nil {
+		return
+	}
+	s.replyCount.Reset(scope)
+}
+
+// replyScope 计算回复计数的会话作用域：群聊用 groupID，私聊用 "dm:"+平台用户ID。
+func replyScope(groupID, platformUserID string) string {
+	if groupID != "" {
+		return groupID
+	}
+	return "dm:" + platformUserID
 }
 
 // reportUsage 上报一次工具循环/流式路径的用量记录。
@@ -231,6 +263,21 @@ func (s *ChatService) assembleContext(ctx context.Context, req *llm.ChatRequest)
 		}
 	}
 	msgs = append(msgs, llm.Message{Role: llm.RoleSystem, Content: systemContent})
+
+	// ── 表情表达规则注入（表情提示词计数器，可选）──
+	// 计数器统计 Bot 在本群/私聊中发出的自然语言（LLM 触发）回复数，
+	// 以"当前计数{count}"告知 LLM 距上次发表情的对话间隔，控制发表情频率
+	// （约每五到十句一次，不过频也不完全不发）。
+	if s.replyCount != nil {
+		count := s.replyCount.Get(replyScope(req.GroupID, req.PlatformUserID))
+		msgs = append(msgs, llm.Message{
+			Role: llm.RoleSystem,
+			Content: fmt.Sprintf(
+				"表情表达规则：当你遇到有对应表情库内的表情的时候，可以发表情（调用 pick_sticker 工具获取表情）来表达自己的感情。"+
+					"不要太过频繁，也不要完全不发，大约每五到十句由 LLM 触发的对话发一次表情。当前计数：%d。",
+				count),
+		})
+	}
 
 	// ── L0 原始对话保持独立 role 消息（user/assistant），不混入 system prompt ──
 	// 群聊话题场景下由话题近期消息（TopicContext.Recent）替代 L0 原文（更贴近当前话题），

--- a/internal/ai/reply_counter.go
+++ b/internal/ai/reply_counter.go
@@ -1,0 +1,45 @@
+package ai
+
+import "sync"
+
+// ReplyCounter 按会话作用域统计 Bot 自然语言回复数。
+//
+// 用途：表情提示词计数器。count 仅统计"以自然语言触发的对话"——
+// 即 Bot 在本群/私聊中实际发出的 LLM 回复条数（命令回复/事件通知不计数），
+// 并通过 System Prompt 注入"当前计数{count}"，让 LLM 感知距上次发表情的
+// 对话间隔，从而控制发表情频率（约每五到十句一次，不过频也不完全不发）。
+//
+// scope 约定：
+//   - 群聊：groupID
+//   - 私聊："dm:" + 平台用户 ID
+type ReplyCounter struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+// NewReplyCounter 创建回复计数器。
+func NewReplyCounter() *ReplyCounter {
+	return &ReplyCounter{counts: make(map[string]int)}
+}
+
+// Get 返回指定作用域的当前计数。
+func (c *ReplyCounter) Get(scope string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.counts[scope]
+}
+
+// Inc 累加指定作用域计数，返回累加后的值。
+func (c *ReplyCounter) Inc(scope string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.counts[scope]++
+	return c.counts[scope]
+}
+
+// Reset 清零指定作用域计数。
+func (c *ReplyCounter) Reset(scope string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.counts, scope)
+}

--- a/internal/bizplugin/music.go
+++ b/internal/bizplugin/music.go
@@ -24,8 +24,8 @@ import (
 //
 // 功能：
 //   - /music 歌曲名 → 搜索网易云音乐，展示前 3 首结果
-//   - 用户回复序号（1/2/3）→ 播放所选歌曲
-//   - 会话 60 秒后自动过期
+//   - 用户回复序号（1/2/3，可 @机器人 或直接发）→ 播放所选歌曲（仅当事人可触发）
+//   - 会话 20 秒后自动过期
 //   - 会话按群+用户隔离
 //
 // 行为树：
@@ -150,21 +150,19 @@ func isMusicCommand(ctx *conduit.MessageContext) bool {
 // isMusicSelect 返回一个条件函数，判断消息是否为点歌序号选择（1/2/3）且存在活跃会话。
 // 使用闭包捕获 StateStore 以检查会话。
 //
-// 防误触规则：
-//   - 群聊必须 @ 机器人（RawMsg 含 "@"）才视为选择，纯数字对话不会误触发；
-//   - 私聊直接发序号即可（无 @ 场景）；
+// 触发规则：
+//   - 群聊与私聊均可直接发序号（1/2/3）触发，无需 @ 机器人；
+//   - 会话按群+用户隔离（musicSessionKey），仅发起点歌的当事人能触发，
+//     非当事人因无活跃会话而不会误触发；
 //   - 会话 20s 内有效（musicSessionTTL）。
 func isMusicSelect(store conduit.StateStore) func(*conduit.MessageContext) bool {
 	return func(ctx *conduit.MessageContext) bool {
 		raw := strings.TrimSpace(ctx.RawMsg)
-		if ctx.IsGroup && !strings.Contains(raw, "@") {
-			return false
-		}
 		sel := extractSelection(raw)
 		if sel != "1" && sel != "2" && sel != "3" {
 			return false
 		}
-		// 检查是否存在活跃会话
+		// 检查是否存在活跃会话（会话按群+用户隔离：仅当事人可触发）
 		sessionKey := musicSessionKey(ctx.GroupID, ctx.UserID)
 		data, err := store.Get(ctx.Ctx, sessionKey)
 		if err != nil || data == "" {

--- a/internal/bizplugin/sticker.go
+++ b/internal/bizplugin/sticker.go
@@ -23,24 +23,27 @@ import (
 // ============================================================
 
 // StickerPlugin 实现自定义表情的收藏与发送：
-//   - /添加表情 <标签>（兼容旧命令 /收表情）：超管收藏消息中的图片（上传 RustFS + 写 sticker_library）
-//   - /发表情 <标签>：按标签发送一张表情；无参数时列出表情库
+//   - /添加表情 <标签>（兼容旧命令 /收表情）：管理员（普通管理员 + 超管）收藏消息中的图片（上传 RustFS + 写 sticker_library）
+//   - /发表情 <标签>：按标签发送一张表情；无参数时发送一张随机表情（默认行为）
+//   - /表情列表：仅管理员（普通管理员 + 超管）可查看表情库清单（必须是 /表情列表 完整命令）
 //   - pick_sticker 工具：LLM 按语义（情绪/语境）检索表情库，返回可发送的图片 URL
 //
 // 行为树：
 //
 //	subtree.sticker → Selector(
 //	  Sequence(isCollectStickerCommand, Action("pipeline.plugin.sticker.collect")),
+//	  Sequence(isListStickerCommand,    Action("pipeline.plugin.sticker.list")),
 //	  Sequence(isSendStickerCommand,    Action("pipeline.plugin.sticker.send")),
 //	)
 //
 // 管线：
 //
 //	pipeline.plugin.sticker.collect → [stickerCollectPass]
+//	pipeline.plugin.sticker.list    → [stickerListPass]
 //	pipeline.plugin.sticker.send    → [stickerSendPass]
 //
 // 数据来源约定（"不导包"）：
-//   - 超管标记：黑板 "bot.is_super_user"（bot 层注入）
+//   - 管理员标记：黑板 "bot.is_super_user"（bot 层注入，普通管理员与超管统一标记）
 //   - 消息图片：黑板 "bot.image_urls"（bot 层注入的图片段 url 列表）
 type StickerPlugin struct {
 	db     *database.DB
@@ -63,7 +66,8 @@ func (p *StickerPlugin) Info() pluginpkg.PluginInfo {
 		Version:     "1.0.0",
 		Commands: []pluginpkg.CommandDef{
 			{Name: "添加表情", Description: "收藏消息中的图片为表情（仅管理员），格式：/添加表情 标签1 标签2", Order: 170},
-			{Name: "发表情", Description: "发送匹配标签的表情，格式：/发表情 标签", Order: 80},
+			{Name: "发表情", Description: "发送匹配标签的表情；无参数时发送随机表情，格式：/发表情 标签", Order: 80},
+			{Name: "表情列表", Description: "查看表情库清单（仅管理员），格式：/表情列表", Order: 90},
 		},
 		SubtreeID: pluginpkg.SubtreeID("sticker"),
 		Tools: []pluginpkg.ToolDef{
@@ -103,6 +107,13 @@ func (p *StickerPlugin) OnInit(ctx *pluginpkg.PluginContext) error {
 	}
 	ctx.Registry.TrackPass("sticker", sendPassID)
 
+	listPassID := pluginpkg.PassID("sticker", "list")
+	listPass := &stickerListPass{db: p.db, logger: p.logger}
+	if err := ctx.Engine.RegisterPass(listPassID, listPass); err != nil {
+		return fmt.Errorf("register sticker list pass: %w", err)
+	}
+	ctx.Registry.TrackPass("sticker", listPassID)
+
 	// 注册管线
 	collectPipelineID := pluginpkg.PipelineID("sticker", "collect")
 	if err := ctx.Engine.RegisterPipeline(conduit.NewPipelineFromIDs(collectPipelineID, collectPassID)); err != nil {
@@ -116,11 +127,21 @@ func (p *StickerPlugin) OnInit(ctx *pluginpkg.PluginContext) error {
 	}
 	ctx.Registry.TrackPipeline("sticker", sendPipelineID)
 
-	// 注册行为树子树：添加表情 / 发表情 命令路由
+	listPipelineID := pluginpkg.PipelineID("sticker", "list")
+	if err := ctx.Engine.RegisterPipeline(conduit.NewPipelineFromIDs(listPipelineID, listPassID)); err != nil {
+		return fmt.Errorf("register sticker list pipeline: %w", err)
+	}
+	ctx.Registry.TrackPipeline("sticker", listPipelineID)
+
+	// 注册行为树子树：添加表情 / 表情列表 / 发表情 命令路由
 	subtree := conduit.NewSelector(
 		conduit.NewSequence(
 			conduit.NewCondition(isCollectStickerCommand),
 			conduit.NewAction(collectPipelineID),
+		),
+		conduit.NewSequence(
+			conduit.NewCondition(isListStickerCommand),
+			conduit.NewAction(listPipelineID),
 		),
 		conduit.NewSequence(
 			conduit.NewCondition(isSendStickerCommand),
@@ -179,21 +200,21 @@ func isSendStickerCommand(ctx *conduit.MessageContext) bool {
 	return strings.HasPrefix(strings.TrimSpace(ctx.RawMsg), "/发表情")
 }
 
+// isListStickerCommand 判断消息是否为 /表情列表 命令。
+// 必须完整匹配 "/表情列表"（trim 后相等），不接受前缀/多余参数，
+// 避免 /表情列表XXX 之类的变体误入该分支。
+func isListStickerCommand(ctx *conduit.MessageContext) bool {
+	return strings.TrimSpace(ctx.RawMsg) == "/表情列表"
+}
+
 // ============================================================
 // 黑板键（bot 层注入，插件按"不导包"约定用字符串字面量）
 // ============================================================
 
 const (
-	blackboardIsSuperUser    = "bot.is_super_user"   // bool 当前用户是否超管
-	blackboardImageURLs      = "bot.image_urls"      // []string 消息中图片段 url 列表
-	blackboardCommandReentry = "bot.command.reentry" // bool 命令重入标记（意图路由/斜杠命令经插件 handler 重入引擎）
+	blackboardIsSuperUser = "bot.is_super_user" // bool 当前用户是否超管（普通管理员与超管统一注入）
+	blackboardImageURLs   = "bot.image_urls"    // []string 消息中图片段 url 列表
 )
-
-// isCommandReentry 判断当前消息是否为插件命令重入（意图路由或斜杠命令触发的插件命令）。
-func isCommandReentry(ctx *conduit.MessageContext) bool {
-	b, _ := ctx.Extra[blackboardCommandReentry].(bool)
-	return b
-}
 
 // ============================================================
 // Pass 实现：添加表情入库
@@ -316,10 +337,10 @@ func (pass *stickerCollectPass) Execute(ctx *conduit.MessageContext) error {
 }
 
 // ============================================================
-// Pass 实现：发表情（发送 / 列表）
+// Pass 实现：发表情（发送）
 // ============================================================
 
-// stickerSendPass 发送表情：/发表情 标签 → 检索并发送一张；/发表情（无参）→ 列出表情库。
+// stickerSendPass 发送表情：/发表情 标签 → 检索并发送一张；/发表情（无参）→ 发送一张随机表情（默认行为）。
 type stickerSendPass struct {
 	db     *database.DB
 	store  *media.ObjectStore
@@ -329,17 +350,10 @@ type stickerSendPass struct {
 func (pass *stickerSendPass) Execute(ctx *conduit.MessageContext) error {
 	keyword := strings.TrimSpace(strings.TrimPrefix(ctx.RawMsg, "/发表情"))
 
-	// 无参数：手动 /发表情 列出表情库；
-	// 意图路由触发但 LLM 未提取到标签参数时（如"发个表情"），给引导而非列列表。
+	// 无参数（手动 /发表情 或意图路由触发但未提取到标签）：
+	// 默认发送一张随机表情，不再列出表情库（列表改由仅管理员的 /表情列表 提供）。
 	if keyword == "" {
-		if isCommandReentry(ctx) {
-			conduit.AppendOutput(ctx, &conduit.Message{
-				UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
-				Content: "想发哪个表情？跟我说「发个XX的表情」就行，或者用 /发表情 XX（如 /发表情 Go）",
-			})
-			return nil
-		}
-		pass.listLibrary(ctx)
+		pass.sendRandom(ctx)
 		return nil
 	}
 
@@ -356,7 +370,7 @@ func (pass *stickerSendPass) Execute(ctx *conduit.MessageContext) error {
 	if len(stickers) == 0 {
 		conduit.AppendOutput(ctx, &conduit.Message{
 			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
-			Content: fmt.Sprintf("表情库里没有匹配「%s」的表情，用 /发表情 看看有哪些吧", keyword),
+			Content: fmt.Sprintf("表情库里没有匹配「%s」的表情，用 /表情列表 看看有哪些吧", keyword),
 		})
 		return nil
 	}
@@ -386,8 +400,69 @@ func (pass *stickerSendPass) Execute(ctx *conduit.MessageContext) error {
 	return nil
 }
 
-// listLibrary 输出表情库清单（ID + 标签）。
-func (pass *stickerSendPass) listLibrary(ctx *conduit.MessageContext) {
+// sendRandom 无参数时的默认行为：从表情库随机取一张发送。
+// 库为空、存储未配置或取图失败时给出对应提示。
+func (pass *stickerSendPass) sendRandom(ctx *conduit.MessageContext) {
+	if pass.db == nil || pass.store == nil {
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "表情存储未配置（RustFS 不可用），无法发送",
+		})
+		return
+	}
+	sticker, err := pass.db.RandomSticker(ctx.Ctx)
+	if err != nil {
+		pass.logger.Error("sticker: 随机取表情失败", zap.Error(err))
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "表情获取失败，请稍后重试",
+		})
+		return
+	}
+	if sticker == nil {
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "表情库还是空的，发张图配上 /添加表情 标签 来收藏吧",
+		})
+		return
+	}
+	presignedURL, err := pass.store.Presign(ctx.Ctx, sticker.ObjectKey, 10*time.Minute)
+	if err != nil {
+		pass.logger.Error("sticker: 随机表情 URL 生成失败", zap.Uint("id", sticker.ID), zap.Error(err))
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "表情发送失败，请稍后重试",
+		})
+		return
+	}
+	// 纯 URL 输出 → bot 层识别为图片段发送
+	conduit.AppendOutput(ctx, &conduit.Message{
+		UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+		Content: presignedURL,
+	})
+}
+
+// ============================================================
+// Pass 实现：表情列表（仅管理员）
+// ============================================================
+
+// stickerListPass 查看表情库清单：校验管理员（普通管理员 + 超管）→ 输出列表。
+type stickerListPass struct {
+	db     *database.DB
+	logger *zap.Logger
+}
+
+func (pass *stickerListPass) Execute(ctx *conduit.MessageContext) error {
+	// 管理员校验：bot 层将普通管理员与超管统一注入 bot.is_super_user
+	isAdmin, _ := ctx.Extra[blackboardIsSuperUser].(bool)
+	if !isAdmin {
+		conduit.AppendOutput(ctx, &conduit.Message{
+			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
+			Content: "只有管理员能查看表情列表哦~",
+		})
+		return nil
+	}
+
 	stickers, err := pass.db.ListStickers(ctx.Ctx, 20)
 	if err != nil {
 		pass.logger.Error("sticker: 列表查询失败", zap.Error(err))
@@ -395,14 +470,14 @@ func (pass *stickerSendPass) listLibrary(ctx *conduit.MessageContext) {
 			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
 			Content: "表情库查询失败，请稍后重试",
 		})
-		return
+		return nil
 	}
 	if len(stickers) == 0 {
 		conduit.AppendOutput(ctx, &conduit.Message{
 			UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
 			Content: "表情库还是空的，发张图配上 /添加表情 标签 来收藏吧",
 		})
-		return
+		return nil
 	}
 
 	var b strings.Builder
@@ -418,6 +493,7 @@ func (pass *stickerSendPass) listLibrary(ctx *conduit.MessageContext) {
 		UserID: ctx.UserID, GroupID: ctx.GroupID, IsGroup: ctx.IsGroup,
 		Content: strings.TrimRight(b.String(), "\n"),
 	})
+	return nil
 }
 
 // ============================================================

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -50,6 +50,7 @@ type Bot struct {
 	stickerInjector StickerEmotionInjector         // 硬性表情规则注入器（表情库插件，nil 表示未启用）
 	stickerCount    int                            // 已回复消息计数（硬性表情规则）
 	stickerTarget   int                            // 触发阈值（10~20 随机，0 表示首次回复前未初始化）
+	stickerCounter  *ai.ReplyCounter               // 表情提示词计数器（与 ChatService 共享；nil 表示未启用）
 	objectStore     *media.ObjectStore             // RustFS 对象存储（nil 时内网图片转 base64 发送不可用）
 	logger          *zap.Logger
 
@@ -184,6 +185,11 @@ func (b *Bot) SetStickerInjector(inj StickerEmotionInjector) {
 	b.stickerTarget = 0
 }
 
+// SetStickerCounter 注入表情提示词计数器（与 ChatService 共享同一实例，表情库插件注册完成后由 main 调用）。
+func (b *Bot) SetStickerCounter(c *ai.ReplyCounter) {
+	b.stickerCounter = c
+}
+
 // maybeInjectSticker 硬性表情规则：每回复 10~20 条消息后，附带一张随机表情。
 // 只在普通消息回复时计数（事件/通知不计）；触发后阈值在 10~20 间重新随机。
 // turnSentSticker 为本轮是否已发出图片（LLM 输出 URL / 插件段 / 命令发图）：
@@ -211,6 +217,10 @@ func (b *Bot) maybeInjectSticker(msg *gateway.NormalizedMessage, turnSentSticker
 	// 纯 URL 输出 → reply 识别为图片段发送（与 LLM 输出 URL 同一路径）
 	if url := b.stickerInjector.Pick(context.Background()); url != "" {
 		b.reply(msg, url)
+		// 同步清零表情提示词计数：硬性规则已补发一张表情，提示词"距上次发表情的对话间隔"归零
+		if b.stickerCounter != nil {
+			b.stickerCounter.Reset(replyScopeFor(msg.GroupID, msg.UserID))
+		}
 	}
 }
 

--- a/internal/bot/roleplay_stream.go
+++ b/internal/bot/roleplay_stream.go
@@ -183,6 +183,24 @@ func (p *RoleplayStreamPass) runStream(
 		}
 	}
 
+	// 表情提示词计数器：统计 Bot 在本群/私聊中发出的自然语言（LLM 触发）回复数。
+	// 本轮回复实际调用了 pick_sticker（回复携带表情）→ 清零重新计数，否则累加。
+	if p.Chat != nil {
+		scope := replyScopeFor(groupID, senderID)
+		sentSticker := false
+		for _, t := range resp.InvolvedTools {
+			if t == "pick_sticker" {
+				sentSticker = true
+				break
+			}
+		}
+		if sentSticker {
+			p.Chat.ResetReplyCount(scope)
+		} else {
+			p.Chat.IncReplyCount(scope)
+		}
+	}
+
 	// 保存对话记录（L0 原始记录，后续由 Compressor 自动压缩）
 	// 使用 context.Background() 因为 streamCtx 可能已接近超时
 	bgCtx := context.Background()
@@ -216,6 +234,15 @@ func respContentLen(resp *llm.ChatResponse) int {
 		return 0
 	}
 	return utf8.RuneCountInString(resp.Content)
+}
+
+// replyScopeFor 计算表情计数的作用域：群聊用 groupID，私聊用 "dm:"+平台用户ID。
+// 与 ai 包内 assembleContext 注入提示词时的作用域保持一致。
+func replyScopeFor(groupID, platformUserID string) string {
+	if groupID != "" {
+		return groupID
+	}
+	return "dm:" + platformUserID
 }
 
 // ── RoleplaySegmentPass：流式段落交付 ──


### PR DESCRIPTION
- 新增 /表情列表：仅管理员（普通管理员+超管）可查看表情库清单，必须完整命令 /表情列表

- /发表情 无参改为默认发送随机表情（列表功能由 /表情列表 承接）

- /music 去掉群聊 @ 限制：@bot 数字与单独发数字均可触发，会话按群+用户隔离保证仅当事人可触发

- 表情提示词计数器：按群/私聊统计 Bot 自然语言回复数，注入 System Prompt 当前计数{count}；回复携带表情（pick_sticker/硬性规则）时清零重新计数