### PR TITLE
fix: 修复思考内容泄露群聊事故与 pgvector 检索 SQL 语法错误

### DIFF
--- a/internal/ai/llm/eino.go
+++ b/internal/ai/llm/eino.go
@@ -9,6 +9,15 @@ import (
 	"github.com/cloudwego/eino/schema"
 )
 
+// DisableThinkingOption 返回关闭推理模型思考的 eino Option。
+// 非流式 Chat 与流式直连路径（chatModel.Stream）共用，
+// 经 OpenAI 兼容层扩展字段 thinking={"type":"disabled"} 透传（DeepSeek 等支持）。
+func DisableThinkingOption() model.Option {
+	return openai.WithExtraFields(map[string]any{
+		"thinking": map[string]any{"type": "disabled"},
+	})
+}
+
 // EinoOptions eino ChatModel 创建参数（provider 无关）
 type EinoOptions struct {
 	Provider    string  // Provider 名称（如 deepseek/qwen/openai），用于计费统计
@@ -117,9 +126,7 @@ func (c *EinoClient) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse,
 	if req.DisableThinking != nil && *req.DisableThinking {
 		// DeepSeek 等推理模型通过 thinking={"type":"disabled"} 关闭思考，
 		// 经 eino 的 ExtraFields 透传（OpenAI 兼容扩展字段）
-		opts = append(opts, openai.WithExtraFields(map[string]any{
-			"thinking": map[string]any{"type": "disabled"},
-		}))
+		opts = append(opts, DisableThinkingOption())
 	}
 
 	resp, err := c.model.Generate(ctx, msgs, opts...)

--- a/internal/ai/stream.go
+++ b/internal/ai/stream.go
@@ -14,6 +14,11 @@ import (
 	"github.com/DaWesen/lanmei-dream/internal/ai/llm"
 )
 
+// maxReasoningChars 流式生成中推理思考的长度上限（字符）。
+// 正文为空而思考超过该值 → 判定模型陷入"只思考不输出"，中止并关思考重试。
+// 事故记录：2026-09-04 群聊事故中模型思考 17528 字符仍无正文，被兜底逻辑整段发出。
+const maxReasoningChars = 500
+
 // ChatStream 以流式方式执行对话，将段落增量写入 segmentCh。
 //
 // 流程：
@@ -77,9 +82,18 @@ func (s *ChatService) chatStreamWithToolLoop(
 	totalOutput := 0
 	var invokedTools []string
 	var lastToolResult string // 最近一次工具结果（LLM 工具轮后无文本时兜底输出）
+	// disableThinking 本轮流式生成是否关闭推理思考。
+	// 推理模型可能把输出预算全部花在 reasoning 上导致正文为空，
+	// 触发思考超限后置位，下一轮以 thinking=disabled 重试。
+	disableThinking := false
 
+roundLoop:
 	for round := 0; round < maxToolCallRounds; round++ {
-		reader, streamErr := chatModel.Stream(ctx, schemaMsgs)
+		var streamOpts []model.Option
+		if disableThinking {
+			streamOpts = append(streamOpts, llm.DisableThinkingOption())
+		}
+		reader, streamErr := chatModel.Stream(ctx, schemaMsgs, streamOpts...)
 		if streamErr != nil {
 			return nil, fmt.Errorf("chat stream: open stream: %w", streamErr)
 		}
@@ -200,6 +214,18 @@ func (s *ChatService) chatStreamWithToolLoop(
 			}
 			if chunk.ReasoningContent != "" {
 				reasoningBuf.WriteString(chunk.ReasoningContent)
+				// 思考超限实时防护：思考远超阈值且正文仍为空，说明模型把输出预算
+				// 全部耗在 reasoning 上（会话表现为"只思考不输出"），继续等待只会
+				// 拖垮超时预算。立即中止本轮流，下一轮关闭思考重试。
+				// 仅未关思考的首轮生效（重试轮不再中止，避免循环）。
+				if reasoningBuf.Len() > maxReasoningChars && segmenter.FullText() == "" && !disableThinking {
+					reader.Close()
+					s.logger.Warn("chat stream: 思考超限，中止本轮并关思考重试",
+						zap.Int("reasoning_len", reasoningBuf.Len()),
+						zap.Int("round", round))
+					disableThinking = true
+					continue roundLoop
+				}
 			}
 			if len(chunk.ToolCalls) > 0 {
 				chunks := []*schema.Message{firstChunk, chunk}
@@ -262,20 +288,10 @@ func (s *ChatService) chatStreamWithToolLoop(
 					return nil, sendErr
 				}
 			}
-		} else if segmenter.FullText() == "" && reasoningBuf.Len() > 0 {
-			// 仅返回 reasoning 而无 content 的空响应：输出思考内容兜底，避免用户看到"没听清"。
-			s.logger.Info("chat stream: 使用 reasoning 兜底输出", zap.Int("reasoning_len", reasoningBuf.Len()))
-			for _, seg := range segmenter.Feed(strings.TrimSpace(reasoningBuf.String())) {
-				if sendErr := sendSegment(ctx, segmentCh, seg); sendErr != nil {
-					return nil, sendErr
-				}
-			}
-			if last := segmenter.Flush(); last != "" {
-				if sendErr := sendSegment(ctx, segmentCh, last); sendErr != nil {
-					return nil, sendErr
-				}
-			}
 		}
+		// 注意：reasoning（思考内容）绝不能作为回复输出给用户——
+		// 它包含提示词线索、检索内容与模型内部推理，泄露即事故。
+		// 空响应统一由上层（roleplay）以关思考重试 / 提示语兜底。
 
 		// 异步存记忆 + 触发压缩
 		s.asyncStoreAndCompress(ctx, req.UserID, req.GroupID, lastMsgContent, queryVec)

--- a/internal/bot/roleplay_stream.go
+++ b/internal/bot/roleplay_stream.go
@@ -156,14 +156,17 @@ func (p *RoleplayStreamPass) runStream(
 	// 注意：assembleContext 会原地修改 req.Messages，重试必须用新请求。
 	if strings.TrimSpace(resp.Content) == "" {
 		p.Logger.Warn("roleplay: LLM 返回空响应，重试一次", zap.String("user", senderID))
+		// 空响应多为推理模型思考耗尽输出预算，重试时关闭思考（与 stream 层超限重试同思路）
+		retryDisableThinking := true
 		retryReq := &llm.ChatRequest{
-			Messages:       []llm.Message{{Role: llm.RoleUser, Content: userMsg}},
-			UserID:         userID,
-			UserName:       nickname,
-			GroupName:      groupID,
-			GroupID:        groupID,
-			PlatformUserID: senderID,
-			TopicContext:   topicCtx,
+			Messages:         []llm.Message{{Role: llm.RoleUser, Content: userMsg}},
+			UserID:           userID,
+			UserName:         nickname,
+			GroupName:        groupID,
+			GroupID:          groupID,
+			PlatformUserID:   senderID,
+			TopicContext:     topicCtx,
+			DisableThinking:  &retryDisableThinking,
 		}
 		retryCtx, retryCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		retryResp, retryErr := p.Chat.ChatStream(retryCtx, retryReq, segCh)

--- a/internal/infra/pgvector.go
+++ b/internal/infra/pgvector.go
@@ -51,15 +51,18 @@ func memoryGroupScope(groupID string, userID int64) (scope string, args []any) {
 
 // Retrieve 根据查询向量检索最相关的 N 条记忆（向量召回）
 func (s *PGVectorStore) Retrieve(ctx context.Context, queryVec []float32, userID int64, groupID string, limit int) ([]*memory.Memory, error) {
+	// 向量以参数形式传入并显式 ::vector 转换：参数化后以 text 到达，
+	// <=> 操作符无法从 $n 推断 vector 类型，缺 cast 会报
+	// operator does not exist: vector <=> text。
+	// （kb/provider/local 的向量召回是同模式的既有正确实现。）
 	vecStr := formatVector(queryVec)
 	scope, args := memoryGroupScope(groupID, userID)
 
 	var rows []model.MemoryVector
-	err := s.orm.WithContext(ctx).
-		Where(scope, args...).
-		Order(fmt.Sprintf("embedding <=> %s", vecStr)).
-		Limit(limit).
-		Find(&rows).Error
+	err := s.orm.WithContext(ctx).Raw(
+		`SELECT * FROM memory_vectors WHERE `+scope+` ORDER BY embedding <=> ?::vector LIMIT ?`,
+		append(args, vecStr, limit)...,
+	).Scan(&rows).Error
 	if err != nil {
 		return nil, fmt.Errorf("pgvector retrieve: %w", err)
 	}


### PR DESCRIPTION
## Summary

修复两个生产事故级问题：

### 1. 思考内容泄露事故（P0）

**事故**：2026-09-04 群聊中，推理模型（deepseek-v4）把输出预算全部花在 reasoning 上（content 始终为空），旧"reasoning 兜底输出"逻辑把 **17528 字符思考全文**发进群聊（含提示词线索、检索内容、模型内部推理），管理员撤回 8+ 条撤不完，最终只能禁言止损。

**修复**：
- `stream.go`：chunk 循环**实时检测**"思考累计 > 500 字符且正文为空" → 立即 `reader.Close()` 中止本轮流，下一轮以 `thinking=disabled` 重试（复用海龟汤 `5e12727` 的关思考思路）。中止条件带"正文为空"防止已发正文时重复输出
- **彻底删除** reasoning 兜底输出分支，任何路径不再输出思考内容
- `eino.go`：抽出 `DisableThinkingOption()`，补上**流式路径此前完全缺失**的 thinking 透传（此前仅非流式 Chat 支持）
- `roleplay_stream.go`：空响应重试同样关思考，双保险

### 2. pgvector 检索 SQL 语法错误（P1）

`Retrieve` 中 `Order(fmt.Sprintf("embedding <=> %s", vecStr))` 拼出裸向量字面量 `[0.1,0.2,...]`，PostgreSQL 报 `syntax error at or near "[" (SQLSTATE 42601)` —— **向量召回每次都失败**，RAG 长期记忆实际不可用。

改为 Raw + `?::vector` 参数化（对齐 `kb/provider/local/search.go` 的既有正确模式；text 参数需显式 cast，否则报 `operator does not exist: vector <=> text`）。

## Test plan

- [x] `go build ./...` + `go vet` 通过
- [x] 本地全链路 e2e（PG/Redis docker + deepseek-v4-flash 推理模型）：发送诱导深度思考消息，服务日志确认思考 501 字符即被中止（0.75s 内），关思考重试后用户收到正常 72 字回复而非思考全文
- [x] 普通闲聊对照无影响、无误触发
- [x] psql 复现旧 SQL 报错 / 新 SQL 正确召回同向向量