### PR TITLE
fix: OpenCode Go 网关请求注入 x-opencode-session 标识头

### DIFF
--- a/internal/ai/llm/eino.go
+++ b/internal/ai/llm/eino.go
@@ -3,11 +3,46 @@ package llm
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/cloudwego/eino-ext/components/model/openai"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
 )
+
+// opencodeSessionHeader / opencodeUserAgent OpenCode Go 网关要求的标识请求头。
+// 官方文档（https://opencode.ai/docs/go/）要求接入方：
+//  1. 明确标识自身（不要过于笼统的 user agent）；
+//  2. 携带 x-opencode-session 以优化提示词缓存。
+// 2026-09-06 起缺失该头的请求会被网关 400 拒绝（生产实测）。
+const (
+	opencodeSessionHeader = "x-opencode-session"
+	opencodeSessionValue  = "lanmei-bot"
+	opencodeUserAgent     = "lanmei-bot"
+)
+
+// opencodeTransport 为 OpenCode Go 网关请求附加标识头的 http.RoundTripper。
+// 覆盖该网关的全部出站请求（对话/流式/视觉），缺失头的请求会被 400 拒绝。
+type opencodeTransport struct {
+	base http.RoundTripper
+}
+
+func (t *opencodeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set(opencodeSessionHeader, opencodeSessionValue)
+	req.Header.Set("User-Agent", opencodeUserAgent)
+	return t.base.RoundTrip(req)
+}
+
+// withOpencodeHeaders 若 BaseURL 指向 OpenCode Go 网关，返回注入标识头的 HTTPClient；
+// 其他 provider（DeepSeek 官方等）返回 nil，行为不变。
+func withOpencodeHeaders(baseURL string) *http.Client {
+	if !strings.Contains(baseURL, "opencode.ai") {
+		return nil
+	}
+	return &http.Client{Transport: &opencodeTransport{base: http.DefaultTransport}}
+}
 
 // DisableThinkingOption 返回关闭推理模型思考的 eino Option。
 // 非流式 Chat 与流式直连路径（chatModel.Stream）共用，
@@ -51,6 +86,9 @@ func NewEinoClient(ctx context.Context, opts *EinoOptions) (*EinoClient, error) 
 		Model:       opts.Model,
 		MaxTokens:   &mt,
 		Temperature: &t,
+		// OpenCode Go 网关：注入标识头 HTTPClient（x-opencode-session + UA），
+		// 2026-09-06 起缺失会被 400 拒绝；其他 provider 该值为 nil 不生效
+		HTTPClient: withOpencodeHeaders(opts.BaseURL),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("llm: eino init: %w", err)


### PR DESCRIPTION
## Summary

OpenCode Go 服务方已通知（2026-09-06 生效）：缺失 `x-opencode-session` 头的请求会被 400 拒绝；官方文档同时要求接入方明确标识自身 UA（[docs](https://opencode.ai/docs/go/) 隐私保护一节）。生产实测 09-07 起缺失该头的请求 **100% 被拒**：

```
Error from provider (Console Go): Request is missing x-opencode-session
and cannot be routed efficiently.
```

主对话、意图分析、视觉理解全部走该网关 → 全链路不可用。

## 修复

`NewEinoClient` 构造时按 `BaseURL` 识别 OpenCode 网关，注入 Transport 包装的 `HTTPClient`，为**全部出站请求**附加：

- `x-opencode-session: lanmei-bot`（官方用于提示词缓存优化）
- `User-Agent: lanmei-bot`（文档要求"明确标识自身，不要过于笼统的 UA"）

**选型说明**：在 Transport 层注入而非 per-request `WithExtraHeader` Option——后者需改所有调用点（Chat / ChatStream / stream.go 直连 / vision 等 6+ 处），漏一处就留坑；前者一处改动全路径覆盖。其他 provider（DeepSeek 官方等）`HTTPClient` 为 nil，行为零变化。

## Test plan

- [x] `go build ./...` + `go vet ./...` 通过
- [x] curl 对照实测：无 header 400 ×3 → 带 header 200
- [x] 本地真实 opencode API 全链路 e2e 5/5（诱导深度思考 / 普通闲聊均正常，含思考超限防护回归）
- [x] 生产已部署：`LLM 就绪` + 心跳正常 + 恢复 0 ERROR