### PR TITLE
fix：3G 关键词插件排除流式段落重入，修复回复静默丢失

### DIFF
--- a/internal/bizplugin/three_g.go
+++ b/internal/bizplugin/three_g.go
@@ -95,9 +95,27 @@ func (p *ThreeGPlugin) OnStop(_ *pluginpkg.PluginContext) error { return nil }
 // 条件判断
 // ============================================================
 
+// keyIsSegment 段落重入标记，与 bot 包 KeyIsSegment 同值（插件"不导包"，用字面量）。
+const keyIsSegment = "bot.is_segment"
+
+// isSegmentReentry 判断消息是否为蓝妹流式回复的段落重入消息。
+// 段落不作关键词触发源：否则插件抢占段落交付分支且出站段无人消费，回复静默丢失
+// （如介绍蒋建华必含 "23Go"，子串命中 "3G"）。
+func isSegmentReentry(ctx *conduit.MessageContext) bool {
+	if raw, ok := ctx.Extra[keyIsSegment]; ok {
+		if b, ok := raw.(bool); ok {
+			return b
+		}
+	}
+	return false
+}
+
 // containsThreeG 判断消息原始文本是否包含关键词 "3G" 或 "3g"。
-// 事件消息（notice）无文本内容，自然不满足条件。
+// 事件消息（notice）无文本内容，自然不满足条件；段落重入消息不作触发源。
 func containsThreeG(ctx *conduit.MessageContext) bool {
+	if isSegmentReentry(ctx) {
+		return false
+	}
 	return strings.Contains(ctx.RawMsg, "3G") || strings.Contains(ctx.RawMsg, "3g")
 }
 


### PR DESCRIPTION
## 问题

流式回复段落重入引擎时，回复含 "23Go"（子串命中 "3G"）会命中 three_g 子树、抢占段落交付分支；插件只写出站段不产出 Output，整条回复静默丢失

## 修复

`containsThreeG` 排除段落重入消息（`bot.is_segment` 标记）：段落是机器人自己的话，不作关键词触发源。

## 验证

- `go build` / `go vet` / `go test` 通过
